### PR TITLE
feat(prover): initL1Current from genesisHeight

### DIFF
--- a/prover/prover.go
+++ b/prover/prover.go
@@ -401,7 +401,7 @@ func (p *Prover) initL1Current(startingBlockID *big.Int) error {
 		}
 
 		if stateVars.LatestVerifiedId == 0 {
-			p.l1Current = 0
+			p.l1Current = stateVars.GenesisHeight
 			return nil
 		}
 


### PR DESCRIPTION
when LatestVerifiedId 0, set l1Current to stateVars.GenesisHeight instead start over