### PR TITLE
fix(prover): fix some oracle proof submission issues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main]
+    branches: [main,fix-oracle-proof-submission]
     tags:
       - "v*"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main,fix-oracle-proof-submission]
+    branches: [main]
     tags:
       - "v*"
 

--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -58,7 +58,7 @@ var (
 		Usage:    "Set whether prover should use oracle prover or not",
 		Category: proverCategory,
 	}
-	OracleProverPrivateKey = &cli.BoolFlag{
+	OracleProverPrivateKey = &cli.StringFlag{
 		Name:     "oracleProverPrivateKey",
 		Usage:    "Private key of oracle prover",
 		Category: proverCategory,

--- a/prover/proof_producer/oracle_proof_producer_test.go
+++ b/prover/proof_producer/oracle_proof_producer_test.go
@@ -50,7 +50,7 @@ func TestHashAndSignOracleProof(t *testing.T) {
 
 	hash := crypto.Keccak256Hash(input)
 
-	sig, _, err := hashAndSignForOracleProof(evidence, privateKey)
+	sig, err := hashAndSignForOracleProof(evidence, privateKey)
 	require.Nil(t, err)
 
 	pubKey, err := crypto.Ecrecover(hash.Bytes(), sig)

--- a/prover/proof_producer/oracle_proof_producer_test.go
+++ b/prover/proof_producer/oracle_proof_producer_test.go
@@ -53,6 +53,8 @@ func TestHashAndSignOracleProof(t *testing.T) {
 	sig, err := hashAndSignForOracleProof(evidence, privateKey)
 	require.Nil(t, err)
 
+	sig[64] = sig[64] - 27
+
 	pubKey, err := crypto.Ecrecover(hash.Bytes(), sig)
 	require.Nil(t, err)
 	isValid := crypto.VerifySignature(pubKey, hash.Bytes(), sig[:64])

--- a/prover/proof_submitter/util.go
+++ b/prover/proof_submitter/util.go
@@ -75,7 +75,7 @@ func sendTxWithBackoff(
 		if err != nil {
 			err = encoding.TryParsingCustomError(err)
 			if isSubmitProofTxErrorRetryable(err, blockID) {
-				log.Info("Retry sending TaikoL1.proveBlock transaction", "reason", err)
+				log.Info("Retry sending TaikoL1.proveBlock transaction", "blockID", blockID, "reason", err)
 				return err
 			}
 

--- a/prover/proof_submitter/valid_proof_submitter.go
+++ b/prover/proof_submitter/valid_proof_submitter.go
@@ -52,8 +52,8 @@ func NewValidProofSubmitter(
 		return nil, err
 	}
 
-	var bytes [32]byte
-	copy(bytes[:], []byte(graffiti))
+	var graffitiBytes [32]byte
+	copy(graffitiBytes[:], []byte(graffiti))
 
 	return &ValidProofSubmitter{
 		rpc:               rpc,
@@ -64,7 +64,7 @@ func NewValidProofSubmitter(
 		proverAddress:     crypto.PubkeyToAddress(proverPrivKey.PublicKey),
 		mutex:             mutex,
 		isOracle:          isOracle,
-		graffiti:          bytes,
+		graffiti:          graffitiBytes,
 	}, nil
 }
 
@@ -181,7 +181,8 @@ func (s *ValidProofSubmitter) SubmitProof(
 
 	if s.isOracle {
 		prover = common.HexToAddress("0x0000000000000000000000000000000000000000")
-		circuitsIdx = uint16(int(zkProof[64])) + 27
+		circuitsIdx = uint16(int(zkProof[64]))
+		evidence.Proof = zkProof[0:64]
 	} else {
 		prover = s.proverAddress
 

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -153,6 +153,7 @@ func InitFromConfig(ctx context.Context, p *Prover, cfg *Config) (err error) {
 			p.cfg.TaikoL2Address,
 			time.Duration(p.protocolConfigs.ProofTimeTarget)*time.Second,
 			oracleProverAddress,
+			p.cfg.Graffiti,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
- change `OracleProverPrivateKey` to a string flag
- only use first 64 bytes of `zkProof` as `evidence.Proof`