### PR TITLE
feat(proposer): add a `--minimalBlockGasLimit` flag to mitigate the potential gas estimation issue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main]
+    branches: [main,minimalBlockGasLimit-flag]
     tags:
       - "v*"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main,minimalBlockGasLimit-flag]
+    branches: [main]
     tags:
       - "v*"
 

--- a/cmd/flags/proposer.go
+++ b/cmd/flags/proposer.go
@@ -45,6 +45,11 @@ var (
 		Usage:    "Time interval to propose empty blocks",
 		Category: proposerCategory,
 	}
+	MinBlockGasLimit = &cli.Uint64Flag{
+		Name:     "minimalBlockGasLimit",
+		Usage:    "Minimal block gasLimit when proposing a block",
+		Category: proposerCategory,
+	}
 )
 
 // All proposer flags.
@@ -56,4 +61,5 @@ var ProposerFlags = MergeFlags(CommonFlags, []cli.Flag{
 	CommitSlot,
 	TxPoolLocals,
 	ProposeEmptyBlocksInterval,
+	MinBlockGasLimit,
 })

--- a/proposer/config.go
+++ b/proposer/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	CommitSlot                 uint64
 	LocalAddresses             []common.Address
 	ProposeEmptyBlocksInterval *time.Duration
+	MinBlockGasLimit           uint64
 }
 
 // NewConfigFromCliContext initializes a Config instance from
@@ -81,5 +82,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		CommitSlot:                 c.Uint64(flags.CommitSlot.Name),
 		LocalAddresses:             localAddresses,
 		ProposeEmptyBlocksInterval: proposeEmptyBlocksInterval,
+		MinBlockGasLimit:           c.Uint64(flags.MinBlockGasLimit.Name),
 	}, nil
 }


### PR DESCRIPTION
If we want to change the geth codebase as less as possible, we can do this. or @cyberhorsey u think changing the geth codebase will be a better option?