### PR TITLE
feat(driver): optimize error handling for `CalldataSyncer`

### DIFF
--- a/driver/chain_syncer/calldata/syncer_test.go
+++ b/driver/chain_syncer/calldata/syncer_test.go
@@ -75,7 +75,7 @@ func (s *CalldataSyncerTestSuite) TestInsertNewHead() {
 	s.Nil(err)
 	l1Head, err := s.s.rpc.L1.BlockByNumber(context.Background(), nil)
 	s.Nil(err)
-	_, rpcErr, payloadErr := s.s.insertNewHead(
+	_, err = s.s.insertNewHead(
 		context.Background(),
 		&bindings.TaikoL1ClientBlockProposed{
 			Id: common.Big1,
@@ -99,8 +99,7 @@ func (s *CalldataSyncerTestSuite) TestInsertNewHead() {
 			L1BlockHash:   testutils.RandomHash(),
 		},
 	)
-	s.Nil(rpcErr)
-	s.Nil(payloadErr)
+	s.Nil(err)
 }
 
 func (s *CalldataSyncerTestSuite) TestTreasuryIncomeAllAnchors() {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -116,7 +116,7 @@ func (d *Driver) Close() {
 // eventLoop starts the main loop of a L2 execution engine's driver.
 func (d *Driver) eventLoop() {
 	defer d.wg.Done()
-	exponentialBackoff := backoff.NewExponentialBackOff()
+	constatnBackoff := backoff.NewConstantBackOff(12 * time.Second)
 
 	// reqSync requests performing a synchronising operation, won't block
 	// if we are already synchronising.
@@ -129,7 +129,7 @@ func (d *Driver) eventLoop() {
 
 	// doSyncWithBackoff performs a synchronising operation with a backoff strategy.
 	doSyncWithBackoff := func() {
-		if err := backoff.Retry(d.doSync, exponentialBackoff); err != nil {
+		if err := backoff.Retry(d.doSync, constatnBackoff); err != nil {
 			log.Error("Sync L2 execution engine's block chain error", "error", err)
 		}
 	}

--- a/pkg/chain_iterator/block_batch_iterator.go
+++ b/pkg/chain_iterator/block_batch_iterator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum"
@@ -163,7 +164,7 @@ func (i *BlockBatchIterator) Iter() error {
 		return nil
 	}
 
-	if err := backoff.Retry(iterOp, backoff.NewExponentialBackOff()); err != nil {
+	if err := backoff.Retry(iterOp, backoff.NewConstantBackOff(12*time.Second)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Since there is no "invalid block" in protocol, we need to retry the block insertion each time there is an error.