### PR TITLE
feat(driver): add proof reward metric

### DIFF
--- a/driver/state/state.go
+++ b/driver/state/state.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"sync/atomic"
 
@@ -173,6 +174,11 @@ func (s *State) startSubscriptions(ctx context.Context) {
 				}
 			case e := <-s.blockVerifiedCh:
 				log.Info("📈 Block verified", "blockID", e.Id, "hash", common.Hash(e.BlockHash), "reward", e.Reward)
+				if e.Reward > math.MaxInt64 {
+					metrics.DriverProofRewardGauge.Update(math.MaxInt64)
+				} else {
+					metrics.DriverProofRewardGauge.Update(int64(e.Reward))
+				}
 			case e := <-s.crossChainSynced:
 				// Verify the protocol synced block, check if it exists in
 				// L2 execution engine.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,6 +21,7 @@ var (
 	DriverL1CurrentHeightGauge  = metrics.NewRegisteredGauge("driver/l1Current/height", nil)
 	DriverL2HeadIDGauge         = metrics.NewRegisteredGauge("driver/l2Head/id", nil)
 	DriverL2VerifiedHeightGauge = metrics.NewRegisteredGauge("driver/l2Verified/id", nil)
+	DriverProofRewardGauge      = metrics.NewRegisteredGauge("driver/proofReward", nil)
 
 	// Proposer
 	ProposerProposeEpochCounter    = metrics.NewRegisteredCounter("proposer/epoch", nil)


### PR DESCRIPTION
would be handy to be able to see this as a time series instead of a constant latest value on status page.