### PR TITLE
feat(all): disable no beacon client seen warning 

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -117,7 +117,6 @@ func (d *Driver) Start() error {
 func (d *Driver) Close() {
 	d.state.Close()
 	d.wg.Wait()
-	log.Info("close.Done()")
 }
 
 // eventLoop starts the main loop of a L2 execution engine's driver.
@@ -146,7 +145,6 @@ func (d *Driver) eventLoop() {
 	for {
 		select {
 		case <-d.ctx.Done():
-			log.Info("eventLoop context exited")
 			return
 		case <-d.syncNotify:
 			doSyncWithBackoff()
@@ -187,7 +185,6 @@ func (d *Driver) reportProtocolStatus() {
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()
-		log.Info("protocolStatus.Done()")
 	}()
 
 	var maxNumBlocks uint64
@@ -210,7 +207,6 @@ func (d *Driver) reportProtocolStatus() {
 	for {
 		select {
 		case <-d.ctx.Done():
-			log.Info("protocol context exited")
 			return
 		case <-ticker.C:
 			vars, err := d.rpc.GetProtocolStateVariables(nil)
@@ -232,23 +228,17 @@ func (d *Driver) reportProtocolStatus() {
 func (d *Driver) checkTransitionConfig() {
 	exchangeTransitionConfigInterval := 60 * time.Second
 	ticker := time.NewTicker(exchangeTransitionConfigInterval)
-	// if d.ctx.Err() != nil {
-	// 	log.Warn("Driver context error", "error", d.ctx.Err())
-	// 	return
-	// }
+
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()
-		log.Info("transition.Done()")
 	}()
 
 	for {
 		select {
 		case <-d.ctx.Done():
-			log.Info("transition context exited")
 			return
 		case <-ticker.C:
-			log.Info("exchanging transition config")
 			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
 				TerminalTotalDifficulty: (*hexutil.Big)(common.Big0),
 				TerminalBlockHash:       common.Hash{},

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -255,7 +255,6 @@ func (d *Driver) checkTransitionConfig() {
 				"transitionconfig", tc)
 		}
 	}
-
 }
 
 // Name returns the application name.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -236,10 +236,6 @@ func (d *Driver) checkTransitionConfig() {
 		d.wg.Done()
 	}()
 
-	// tmp := new(big.Int)
-	// tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
-	// ttd := (*hexutil.Big)(tmp)
-
 	for {
 		select {
 		case <-d.ctx.Done():

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -251,7 +251,7 @@ func (d *Driver) checkTransitionConfig() {
 				log.Error("Failed to exchange Transition Configuration", "error", err)
 				continue
 			}
-			log.Info("exchanged transition config",
+			log.Info("Exchanged transition config",
 				"transitionconfig", tc)
 		}
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -226,6 +226,11 @@ func (d *Driver) reportProtocolStatus() {
 }
 
 func (d *Driver) checkTransitionConfig() {
+	if d.ctx.Err() != nil {
+		log.Warn("Driver context error", "error", d.ctx.Err())
+		return
+	}
+
 	ticker := time.NewTicker(60 * time.Second)
 	defer func() {
 		ticker.Stop()

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -104,7 +104,7 @@ func InitFromConfig(ctx context.Context, d *Driver, cfg *Config) (err error) {
 
 // Start starts the driver instance.
 func (d *Driver) Start() error {
-	d.wg.Add(2)
+	d.wg.Add(3)
 	go d.eventLoop()
 	go d.reportProtocolStatus()
 	go d.checkTransitionConfig()
@@ -237,14 +237,16 @@ func (d *Driver) checkTransitionConfig() {
 		d.wg.Done()
 	}()
 
+	tmp := new(big.Int)
+	tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
+	ttd := (*hexutil.Big)(tmp)
+
 	for {
 		select {
 		case <-d.ctx.Done():
 			return
 		case <-ticker.C:
-			tmp := new(big.Int)
-			tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
-			ttd := (*hexutil.Big)(tmp)
+
 			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
 				TerminalTotalDifficulty: ttd,
 				TerminalBlockHash:       common.Hash{},

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"context"
-	"math/big"
 	"sync"
 	"time"
 
@@ -237,9 +236,9 @@ func (d *Driver) checkTransitionConfig() {
 		d.wg.Done()
 	}()
 
-	tmp := new(big.Int)
-	tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
-	ttd := (*hexutil.Big)(tmp)
+	// tmp := new(big.Int)
+	// tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
+	// ttd := (*hexutil.Big)(tmp)
 
 	for {
 		select {
@@ -248,7 +247,7 @@ func (d *Driver) checkTransitionConfig() {
 		case <-ticker.C:
 
 			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
-				TerminalTotalDifficulty: ttd,
+				TerminalTotalDifficulty: (*hexutil.Big)(common.Big0),
 				TerminalBlockHash:       common.Hash{},
 				TerminalBlockNumber:     0,
 			})

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -146,6 +146,7 @@ func (d *Driver) eventLoop() {
 	for {
 		select {
 		case <-d.ctx.Done():
+			log.Info("eventLoop context exited")
 			return
 		case <-d.syncNotify:
 			doSyncWithBackoff()
@@ -229,12 +230,12 @@ func (d *Driver) reportProtocolStatus() {
 }
 
 func (d *Driver) checkTransitionConfig() {
-	if d.ctx.Err() != nil {
-		log.Warn("Driver context error", "error", d.ctx.Err())
-		return
-	}
-
-	ticker := time.NewTicker(60 * time.Second)
+	exchangeTransitionConfigInterval := 60 * time.Second
+	ticker := time.NewTicker(exchangeTransitionConfigInterval)
+	// if d.ctx.Err() != nil {
+	// 	log.Warn("Driver context error", "error", d.ctx.Err())
+	// 	return
+	// }
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()
@@ -247,7 +248,7 @@ func (d *Driver) checkTransitionConfig() {
 			log.Info("transition context exited")
 			return
 		case <-ticker.C:
-
+			log.Info("exchanging transition config")
 			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
 				TerminalTotalDifficulty: (*hexutil.Big)(common.Big0),
 				TerminalBlockHash:       common.Hash{},

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -9,10 +9,10 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/holiman/uint256"
 	chainSyncer "github.com/taikoxyz/taiko-client/driver/chain_syncer"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-client/pkg/rpc"
@@ -242,15 +242,13 @@ func (d *Driver) checkTransitionConfig() {
 		case <-d.ctx.Done():
 			return
 		case <-ticker.C:
-			i := new(big.Int)
-			i.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
-			ttd := new(uint256.Int)
-			ttd.SetFromBig(i)
+			tmp := new(big.Int)
+			tmp.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
+			ttd := (*hexutil.Big)(tmp)
 			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
-				// TerminalTotalDifficulty: 115792089237316195423570985008687907853269984665640564039457584007913129638912,
-				// not sure how to convert uint256 to *hexutil.Big
-				TerminalBlockHash:   common.Hash{},
-				TerminalBlockNumber: 0,
+				TerminalTotalDifficulty: ttd,
+				TerminalBlockHash:       common.Hash{},
+				TerminalBlockNumber:     0,
 			})
 			if err != nil {
 				log.Error("Failed to exchange Transition Configuration", "error", err)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -209,6 +209,7 @@ func (d *Driver) reportProtocolStatus() {
 	for {
 		select {
 		case <-d.ctx.Done():
+			log.Info("protocol context exited")
 			return
 		case <-ticker.C:
 			vars, err := d.rpc.GetProtocolStateVariables(nil)
@@ -243,6 +244,7 @@ func (d *Driver) checkTransitionConfig() {
 	for {
 		select {
 		case <-d.ctx.Done():
+			log.Info("transition context exited")
 			return
 		case <-ticker.C:
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -228,7 +228,6 @@ func (d *Driver) reportProtocolStatus() {
 func (d *Driver) checkTransitionConfig() {
 	exchangeTransitionConfigInterval := 60 * time.Second
 	ticker := time.NewTicker(exchangeTransitionConfigInterval)
-
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -2,13 +2,17 @@ package driver
 
 import (
 	"context"
+	"math/big"
 	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
 	chainSyncer "github.com/taikoxyz/taiko-client/driver/chain_syncer"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-client/pkg/rpc"
@@ -103,6 +107,7 @@ func (d *Driver) Start() error {
 	d.wg.Add(2)
 	go d.eventLoop()
 	go d.reportProtocolStatus()
+	go d.checkTransitionConfig()
 
 	return nil
 }
@@ -218,6 +223,39 @@ func (d *Driver) reportProtocolStatus() {
 			)
 		}
 	}
+}
+
+func (d *Driver) checkTransitionConfig() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer func() {
+		ticker.Stop()
+		d.wg.Done()
+	}()
+
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-ticker.C:
+			i := new(big.Int)
+			i.SetString("115792089237316195423570985008687907853269984665640564039457584007913129638912", 10)
+			ttd := new(uint256.Int)
+			ttd.SetFromBig(i)
+			tc, err := d.rpc.L2Engine.ExchangeTransitionConfiguration(d.ctx, &engine.TransitionConfigurationV1{
+				// TerminalTotalDifficulty: 115792089237316195423570985008687907853269984665640564039457584007913129638912,
+				// not sure how to convert uint256 to *hexutil.Big
+				TerminalBlockHash:   common.Hash{},
+				TerminalBlockNumber: 0,
+			})
+			if err != nil {
+				log.Error("Failed to exchange Transition Configuration", "error", err)
+				continue
+			}
+			log.Info("exchanged transition config",
+				"transitionconfig", tc)
+		}
+	}
+
 }
 
 // Name returns the application name.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -115,6 +115,7 @@ func (d *Driver) Start() error {
 func (d *Driver) Close() {
 	d.state.Close()
 	d.wg.Wait()
+	log.Info("close.Done()")
 }
 
 // eventLoop starts the main loop of a L2 execution engine's driver.
@@ -184,6 +185,7 @@ func (d *Driver) reportProtocolStatus() {
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()
+		log.Info("protocolStatus.Done()")
 	}()
 
 	var maxNumBlocks uint64
@@ -234,6 +236,7 @@ func (d *Driver) checkTransitionConfig() {
 	defer func() {
 		ticker.Stop()
 		d.wg.Done()
+		log.Info("transition.Done()")
 	}()
 
 	for {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -174,6 +174,12 @@ func (s *DriverTestSuite) TestStartClose() {
 	s.d.Close()
 }
 
+func (s *DriverTestSuite) TestCheckTransitionConfig() {
+	s.d.checkTransitionConfig()
+	s.cancel()
+	s.d.Close()
+}
+
 func TestDriverTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverTestSuite))
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -176,7 +176,7 @@ func (s *DriverTestSuite) TestStartClose() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		<-time.After(121 * time.Second)
+		<-time.After(61 * time.Second)
 		s.cancel()
 	}()
 	s.d.wg.Add(1)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -168,15 +168,15 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 	s.Nil(s.d.doSync())
 }
 
-func (s *DriverTestSuite) TestCheckTransitionConfig() {
-	go func() {
-		time.After(120 * time.Second)
-		s.cancel()
-		s.d.Close()
-	}()
-	s.d.wg.Add(1)
-	s.d.checkTransitionConfig()
-}
+// func (s *DriverTestSuite) TestCheckTransitionConfig() {
+// 	go func() {
+// 		time.After(120 * time.Second)
+// 		s.cancel()
+// 		s.d.Close()
+// 	}()
+// 	s.d.wg.Add(1)
+// 	s.d.checkTransitionConfig()
+// }
 
 func (s *DriverTestSuite) TestStartClose() {
 	s.Nil(s.d.Start())

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -176,7 +176,7 @@ func (s *DriverTestSuite) TestStartClose() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		time.After(121 * time.Second)
+		<-time.After(121 * time.Second)
 		s.cancel()
 	}()
 	s.d.checkTransitionConfig()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -168,19 +168,19 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 	s.Nil(s.d.doSync())
 }
 
+func (s *DriverTestSuite) TestCheckTransitionConfig() {
+	go func() {
+		time.After(61 * time.Second)
+		s.d.ctx.Done()
+	}()
+	s.d.wg.Add(1)
+	s.d.checkTransitionConfig()
+}
+
 func (s *DriverTestSuite) TestStartClose() {
 	s.Nil(s.d.Start())
 	s.cancel()
 	s.d.Close()
-}
-
-func (s *DriverTestSuite) TestCheckTransitionConfig() {
-	go func() {
-		time.After(61 * time.Second)
-		s.cancel()
-	}()
-	s.d.wg.Add(1)
-	s.d.checkTransitionConfig()
 }
 
 func TestDriverTestSuite(t *testing.T) {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -175,16 +175,12 @@ func (s *DriverTestSuite) TestStartClose() {
 }
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
+	go func() {
+		time.After(121 * time.Second)
+		s.cancel()
+	}()
 	s.d.checkTransitionConfig()
-	time.Sleep(120 * time.Second)
-	s.cancel()
-	s.d.wg.Done()
 }
-
-// func (s *DriverTestSuite) TestReportProtocolStatus() {
-// 	s.d.reportProtocolStatus()
-// 	s.d.wg.Done()
-// }
 
 func TestDriverTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverTestSuite))

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -168,15 +168,15 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 	s.Nil(s.d.doSync())
 }
 
-// func (s *DriverTestSuite) TestCheckTransitionConfig() {
-// 	go func() {
-// 		time.After(120 * time.Second)
-// 		s.cancel()
-// 		s.d.Close()
-// 	}()
-// 	s.d.wg.Add(1)
-// 	s.d.checkTransitionConfig()
-// }
+func (s *DriverTestSuite) TestCheckTransitionConfig() {
+	go func() {
+		time.After(70 * time.Second)
+		s.cancel()
+		s.d.Close()
+	}()
+	s.d.wg.Add(1)
+	s.d.checkTransitionConfig()
+}
 
 func (s *DriverTestSuite) TestStartClose() {
 	s.Nil(s.d.Start())

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -168,16 +168,6 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 	s.Nil(s.d.doSync())
 }
 
-func (s *DriverTestSuite) TestCheckTransitionConfig() {
-	go func() {
-		<-time.After(120 * time.Second)
-		s.cancel()
-		s.d.Close()
-	}()
-	s.d.wg.Add(1)
-	s.d.checkTransitionConfig()
-}
-
 func (s *DriverTestSuite) TestStartClose() {
 	s.Nil(s.d.Start())
 	s.cancel()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -174,17 +174,17 @@ func (s *DriverTestSuite) TestStartClose() {
 	s.d.Close()
 }
 
-// func (s *DriverTestSuite) TestCheckTransitionConfig() {
-// 	s.d.checkTransitionConfig()
-// 	s.cancel()
-// 	s.d.Close()
-// }
-
-func (s *DriverTestSuite) TestReportProtocolStatus() {
-	s.d.reportProtocolStatus()
+func (s *DriverTestSuite) TestCheckTransitionConfig() {
+	s.d.checkTransitionConfig()
+	time.Sleep(120 * time.Second)
 	s.cancel()
-	s.d.Close()
+	s.d.wg.Done()
 }
+
+// func (s *DriverTestSuite) TestReportProtocolStatus() {
+// 	s.d.reportProtocolStatus()
+// 	s.d.wg.Done()
+// }
 
 func TestDriverTestSuite(t *testing.T) {
 	suite.Run(t, new(DriverTestSuite))

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -179,6 +179,7 @@ func (s *DriverTestSuite) TestCheckTransitionConfig() {
 		<-time.After(121 * time.Second)
 		s.cancel()
 	}()
+	s.d.wg.Add(1)
 	s.d.checkTransitionConfig()
 }
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -18,11 +18,9 @@ import (
 
 type DriverTestSuite struct {
 	testutils.ClientTestSuite
-	cancel  context.CancelFunc
-	cancel2 context.CancelFunc
-	p       *proposer.Proposer
-	d       *Driver
-	d2      *Driver
+	cancel context.CancelFunc
+	p      *proposer.Proposer
+	d      *Driver
 }
 
 func (s *DriverTestSuite) SetupTest() {
@@ -46,18 +44,6 @@ func (s *DriverTestSuite) SetupTest() {
 	}))
 	s.d = d
 
-	d2 := new(Driver)
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	s.cancel2 = cancel2
-	s.Nil(InitFromConfig(ctx2, d2, &Config{
-		L1Endpoint:       os.Getenv("L1_NODE_WS_ENDPOINT"),
-		L2Endpoint:       os.Getenv("L2_EXECUTION_ENGINE_WS_ENDPOINT"),
-		L2EngineEndpoint: os.Getenv("L2_EXECUTION_ENGINE_AUTH_ENDPOINT"),
-		TaikoL1Address:   common.HexToAddress(os.Getenv("TAIKO_L1_ADDRESS")),
-		TaikoL2Address:   common.HexToAddress(os.Getenv("TAIKO_L2_ADDRESS")),
-		JwtSecret:        string(jwtSecret),
-	}))
-	s.d2 = d2
 	// Init proposer
 	p := new(proposer.Proposer)
 
@@ -184,11 +170,11 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		time.After(61 * time.Second)
-		s.cancel2()
+		time.After(120 * time.Second)
+		s.cancel()
 	}()
-	s.d2.wg.Add(1)
-	s.d2.checkTransitionConfig()
+	s.d.wg.Add(1)
+	s.d.checkTransitionConfig()
 }
 
 func (s *DriverTestSuite) TestStartClose() {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -176,7 +176,7 @@ func (s *DriverTestSuite) TestStartClose() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		<-time.After(61 * time.Second)
+		time.After(61 * time.Second)
 		s.cancel()
 	}()
 	s.d.wg.Add(1)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -46,17 +46,17 @@ func (s *DriverTestSuite) SetupTest() {
 	}))
 	s.d = d
 
+	d2 := new(Driver)
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	s.cancel2 = cancel2
-	d2 := new(Driver)
-	InitFromConfig(ctx2, d2, &Config{
+	s.Nil(InitFromConfig(ctx2, d2, &Config{
 		L1Endpoint:       os.Getenv("L1_NODE_WS_ENDPOINT"),
 		L2Endpoint:       os.Getenv("L2_EXECUTION_ENGINE_WS_ENDPOINT"),
 		L2EngineEndpoint: os.Getenv("L2_EXECUTION_ENGINE_AUTH_ENDPOINT"),
 		TaikoL1Address:   common.HexToAddress(os.Getenv("TAIKO_L1_ADDRESS")),
 		TaikoL2Address:   common.HexToAddress(os.Getenv("TAIKO_L2_ADDRESS")),
 		JwtSecret:        string(jwtSecret),
-	})
+	}))
 	s.d2 = d2
 	// Init proposer
 	p := new(proposer.Proposer)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -172,6 +172,7 @@ func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
 		time.After(120 * time.Second)
 		s.cancel()
+		s.d.Close()
 	}()
 	s.d.wg.Add(1)
 	s.d.checkTransitionConfig()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -170,7 +170,7 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		time.After(120 * time.Second)
+		<-time.After(120 * time.Second)
 		s.cancel()
 		s.d.Close()
 	}()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -18,9 +18,11 @@ import (
 
 type DriverTestSuite struct {
 	testutils.ClientTestSuite
-	cancel context.CancelFunc
-	p      *proposer.Proposer
-	d      *Driver
+	cancel  context.CancelFunc
+	cancel2 context.CancelFunc
+	p       *proposer.Proposer
+	d       *Driver
+	d2      *Driver
 }
 
 func (s *DriverTestSuite) SetupTest() {
@@ -44,6 +46,18 @@ func (s *DriverTestSuite) SetupTest() {
 	}))
 	s.d = d
 
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	s.cancel2 = cancel2
+	d2 := new(Driver)
+	InitFromConfig(ctx2, d2, &Config{
+		L1Endpoint:       os.Getenv("L1_NODE_WS_ENDPOINT"),
+		L2Endpoint:       os.Getenv("L2_EXECUTION_ENGINE_WS_ENDPOINT"),
+		L2EngineEndpoint: os.Getenv("L2_EXECUTION_ENGINE_AUTH_ENDPOINT"),
+		TaikoL1Address:   common.HexToAddress(os.Getenv("TAIKO_L1_ADDRESS")),
+		TaikoL2Address:   common.HexToAddress(os.Getenv("TAIKO_L2_ADDRESS")),
+		JwtSecret:        string(jwtSecret),
+	})
+	s.d2 = d2
 	// Init proposer
 	p := new(proposer.Proposer)
 
@@ -171,10 +185,10 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
 		time.After(61 * time.Second)
-		s.d.ctx.Done()
+		s.cancel2()
 	}()
-	s.d.wg.Add(1)
-	s.d.checkTransitionConfig()
+	s.d2.wg.Add(1)
+	s.d2.checkTransitionConfig()
 }
 
 func (s *DriverTestSuite) TestStartClose() {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -174,8 +174,14 @@ func (s *DriverTestSuite) TestStartClose() {
 	s.d.Close()
 }
 
-func (s *DriverTestSuite) TestCheckTransitionConfig() {
-	s.d.checkTransitionConfig()
+// func (s *DriverTestSuite) TestCheckTransitionConfig() {
+// 	s.d.checkTransitionConfig()
+// 	s.cancel()
+// 	s.d.Close()
+// }
+
+func (s *DriverTestSuite) TestReportProtocolStatus() {
+	s.d.reportProtocolStatus()
 	s.cancel()
 	s.d.Close()
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -170,7 +170,7 @@ func (s *DriverTestSuite) TestDoSyncNoNewL2Blocks() {
 
 func (s *DriverTestSuite) TestCheckTransitionConfig() {
 	go func() {
-		time.After(70 * time.Second)
+		time.After(120 * time.Second)
 		s.cancel()
 		s.d.Close()
 	}()

--- a/pkg/rpc/engine.go
+++ b/pkg/rpc/engine.go
@@ -64,15 +64,13 @@ func (c *EngineClient) GetPayload(
 	return result.ExecutionPayload, nil
 }
 
+// ExchangeTransitionConfiguration exchanges transition configs with the L2 execution engine.
 func (c *EngineClient) ExchangeTransitionConfiguration(
 	ctx context.Context,
 	cfg *engine.TransitionConfigurationV1,
 ) (*engine.TransitionConfigurationV1, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	var result *engine.TransitionConfigurationV1
-	if err := c.Client.CallContext(timeoutCtx, &result, "engine_exchangeTransitionConfigurationV1", cfg); err != nil {
+	if err := c.Client.CallContext(ctx, &result, "engine_exchangeTransitionConfigurationV1", cfg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/rpc/engine.go
+++ b/pkg/rpc/engine.go
@@ -63,3 +63,18 @@ func (c *EngineClient) GetPayload(
 
 	return result.ExecutionPayload, nil
 }
+
+func (c *EngineClient) ExchangeTransitionConfiguration(
+	ctx context.Context,
+	cfg *engine.TransitionConfigurationV1,
+) (*engine.TransitionConfigurationV1, error) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var result *engine.TransitionConfigurationV1
+	if err := c.Client.CallContext(timeoutCtx, &result, "engine_exchangeTransitionConfigurationV1", cfg); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/pkg/rpc/engine_test.go
+++ b/pkg/rpc/engine_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,5 +30,12 @@ func TestL2EngineBorbidden(t *testing.T) {
 		context.Background(),
 		&engine.PayloadID{},
 	)
+	require.ErrorContains(t, err, "Unauthorized")
+
+	_, err = c.L2Engine.ExchangeTransitionConfiguration(context.Background(), &engine.TransitionConfigurationV1{
+		TerminalTotalDifficulty: (*hexutil.Big)(common.Big0),
+		TerminalBlockHash:       common.Hash{},
+		TerminalBlockNumber:     0,
+	})
 	require.ErrorContains(t, err, "Unauthorized")
 }


### PR DESCRIPTION
By on interval calling ExchangeTransitionConfigurationV1 through the engine, lastTransitionUpdate gets updated and the beacon warning is consequently never triggered. Default TransitionConfiguration used according to [execution api specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md)