### PR TITLE
fix(driver): fix a P2P sync issue

### DIFF
--- a/driver/chain_syncer/beaconsync/syncer.go
+++ b/driver/chain_syncer/beaconsync/syncer.go
@@ -51,8 +51,6 @@ func (s *Syncer) TriggerBeaconSync() error {
 				"newBlockID", blockID,
 			)
 		}
-
-		return nil
 	}
 
 	status, err := s.rpc.L2Engine.NewPayload(


### PR DESCRIPTION
This may make node unable to start inserting pending blocks