### PR TITLE
feat(prover): generate an oracle proof if incoming proof is incorrect

### DIFF
--- a/prover/prover.go
+++ b/prover/prover.go
@@ -831,7 +831,7 @@ func (p *Prover) checkProofWindowExpired(ctx context.Context, l1Height, blockId 
 
 		if forkChoice.Prover == zeroAddress {
 			// we can generate the proof, no proof came in by proof window expiring
-			p.proveNotify <- big.NewInt(int64(blockId))
+			p.proveNotify <- big.NewInt(int64(l1Height))
 		} else {
 			// we need to check the block hash vs the proof's blockHash to see
 			// if the proof is valid or not


### PR DESCRIPTION
if parentGasUsed and parentHash are correct, but blockHash is incorrect, generate an oracle proof and skip the current `proofWindowExpired` check.

also include 3 general fixes:
-  we were not checking blockHash before when checking isValidProof before cancelling proof generation even for regular provers, so fixed that.

- we should remove the block from `p.currentBlocksWaitingForProofWindow` in prover regardless of what happens after the proof window expires, right now it was only in one conditional block, which would lead to the map growing very large unnecessarily and checking too many blocks. we should also compare block hash here.

- was passing in l2BlockId instead of l1Height to `p.proveNotify` when checking expired windows