### PR TITLE
feat(prover): flag for proving unassigned proofs or not

### DIFF
--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -73,18 +73,18 @@ var (
 		Name:     "taikoProverPoolL1",
 		Usage:    "TaikoProverPoolL1 contract address",
 		Required: true,
-		Category: commonCategory,
+		Category: proverCategory,
 	}
 	CheckProofWindowExpiredInterval = &cli.Uint64Flag{
 		Name:     "prover.checkProofWindowExpiredInterval",
 		Usage:    "Interval in seconds to check for expired proof windows from other provers",
-		Category: commonCategory,
+		Category: proverCategory,
 		Value:    15,
 	}
 	ProveExpiredProofs = &cli.BoolFlag{
 		Name:     "prover.proveExpiredProofs",
 		Usage:    "Whether you want to prover expired proofs, or only work on assigned proofs",
-		Category: commonCategory,
+		Category: proverCategory,
 		Value:    true,
 	}
 )

--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -81,6 +81,12 @@ var (
 		Category: commonCategory,
 		Value:    15,
 	}
+	ProveExpiredProofs = &cli.BoolFlag{
+		Name:     "prover.proveExpiredProofs",
+		Usage:    "Wh",
+		Category: commonCategory,
+		Value:    true,
+	}
 )
 
 // All prover flags.
@@ -100,4 +106,5 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	Graffiti,
 	TaikoProverPoolL1Address,
 	CheckProofWindowExpiredInterval,
+	ProveExpiredProofs,
 })

--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -81,9 +81,9 @@ var (
 		Category: proverCategory,
 		Value:    15,
 	}
-	ProveExpiredProofs = &cli.BoolFlag{
-		Name:     "prover.proveExpiredProofs",
-		Usage:    "Whether you want to prover expired proofs, or only work on assigned proofs",
+	ProveUnassignedBlocks = &cli.BoolFlag{
+		Name:     "prover.ProveUnassignedBlocks",
+		Usage:    "Whether you want to prove unassigned blocks, or only work on assigned proofs",
 		Category: proverCategory,
 		Value:    true,
 	}
@@ -106,5 +106,5 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	Graffiti,
 	TaikoProverPoolL1Address,
 	CheckProofWindowExpiredInterval,
-	ProveExpiredProofs,
+	ProveUnassignedBlocks,
 })

--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -83,7 +83,7 @@ var (
 	}
 	ProveExpiredProofs = &cli.BoolFlag{
 		Name:     "prover.proveExpiredProofs",
-		Usage:    "Wh",
+		Usage:    "Whether you want to prover expired proofs, or only work on assigned proofs",
 		Category: commonCategory,
 		Value:    true,
 	}

--- a/prover/config.go
+++ b/prover/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	BackOffMaxRetrys                uint64
 	BackOffRetryInterval            time.Duration
 	CheckProofWindowExpiredInterval time.Duration
+	ProveExpiredProofs              bool
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -121,5 +122,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		CheckProofWindowExpiredInterval: time.Duration(
 			c.Uint64(flags.CheckProofWindowExpiredInterval.Name),
 		) * time.Second,
+		ProveExpiredProofs: c.Bool(flags.ProveExpiredProofs.Name),
 	}, nil
 }

--- a/prover/config.go
+++ b/prover/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	BackOffMaxRetrys                uint64
 	BackOffRetryInterval            time.Duration
 	CheckProofWindowExpiredInterval time.Duration
-	ProveExpiredProofs              bool
+	ProveUnassignedBlocks           bool
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -122,6 +122,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		CheckProofWindowExpiredInterval: time.Duration(
 			c.Uint64(flags.CheckProofWindowExpiredInterval.Name),
 		) * time.Second,
-		ProveExpiredProofs: c.Bool(flags.ProveExpiredProofs.Name),
+		ProveUnassignedBlocks: c.Bool(flags.ProveUnassignedBlocks.Name),
 	}, nil
 }

--- a/prover/config_test.go
+++ b/prover/config_test.go
@@ -25,6 +25,7 @@ var testFlags = []cli.Flag{
 	&cli.StringFlag{Name: flags.Graffiti.Name},
 	&cli.StringFlag{Name: flags.TaikoProverPoolL1Address.Name},
 	&cli.Uint64Flag{Name: flags.CheckProofWindowExpiredInterval.Name},
+	&cli.BoolFlag{Name: flags.ProveExpiredProofs.Name},
 }
 
 func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
@@ -62,6 +63,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		)
 		s.Equal("", c.Graffiti)
 		s.Equal(30*time.Second, c.CheckProofWindowExpiredInterval)
+		s.Equal(true, c.ProveExpiredProofs)
 		s.Nil(new(Prover).InitFromCli(context.Background(), ctx))
 
 		return err
@@ -83,6 +85,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		"-" + flags.OracleProverPrivateKey.Name, os.Getenv("L1_PROVER_PRIVATE_KEY"),
 		"-" + flags.Graffiti.Name, "",
 		"-" + flags.CheckProofWindowExpiredInterval.Name, "30",
+		"-" + flags.ProveExpiredProofs.Name, "true",
 	}))
 }
 

--- a/prover/config_test.go
+++ b/prover/config_test.go
@@ -25,7 +25,7 @@ var testFlags = []cli.Flag{
 	&cli.StringFlag{Name: flags.Graffiti.Name},
 	&cli.StringFlag{Name: flags.TaikoProverPoolL1Address.Name},
 	&cli.Uint64Flag{Name: flags.CheckProofWindowExpiredInterval.Name},
-	&cli.BoolFlag{Name: flags.ProveExpiredProofs.Name},
+	&cli.BoolFlag{Name: flags.ProveUnassignedBlocks.Name},
 }
 
 func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
@@ -63,7 +63,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		)
 		s.Equal("", c.Graffiti)
 		s.Equal(30*time.Second, c.CheckProofWindowExpiredInterval)
-		s.Equal(true, c.ProveExpiredProofs)
+		s.Equal(true, c.ProveUnassignedBlocks)
 		s.Nil(new(Prover).InitFromCli(context.Background(), ctx))
 
 		return err
@@ -85,7 +85,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		"-" + flags.OracleProverPrivateKey.Name, os.Getenv("L1_PROVER_PRIVATE_KEY"),
 		"-" + flags.Graffiti.Name, "",
 		"-" + flags.CheckProofWindowExpiredInterval.Name, "30",
-		"-" + flags.ProveExpiredProofs.Name, "true",
+		"-" + flags.ProveUnassignedBlocks.Name, "true",
 	}))
 }
 

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -508,10 +508,6 @@ func (p *Prover) onBlockProposed(
 		}
 
 		if !skipProofWindowExpiredCheck {
-			if block.AssignedProver == zeroAddress {
-				// anyone can prove, dont need to check the proofWindowExpired
-			}
-
 			proofWindowExpired := uint64(time.Now().Unix()) > block.ProposedAt+block.ProofWindow
 			// zero address means anyone can prove, proofWindowExpired means anyone can prove even if not zero address
 			if block.AssignedProver != p.proverAddress && block.AssignedProver != zeroAddress && !proofWindowExpired {

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -514,9 +514,11 @@ func (p *Prover) onBlockProposed(
 				log.Info("Proposed block not proveable", "blockID", event.BlockId, "prover", block.AssignedProver.Hex())
 
 				// if we cant prove it
-				p.currentBlocksWaitingForProofWindowMutex.Lock()
-				p.currentBlocksWaitingForProofWindow[event.Meta.Id] = event.Raw.BlockNumber
-				p.currentBlocksWaitingForProofWindowMutex.Unlock()
+				if p.cfg.ProveExpiredProofs {
+					p.currentBlocksWaitingForProofWindowMutex.Lock()
+					p.currentBlocksWaitingForProofWindow[event.Meta.Id] = event.Raw.BlockNumber
+					p.currentBlocksWaitingForProofWindowMutex.Unlock()
+				}
 
 				return nil
 			}

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -513,7 +513,8 @@ func (p *Prover) onBlockProposed(
 			if block.AssignedProver != p.proverAddress && block.AssignedProver != zeroAddress && !proofWindowExpired {
 				log.Info("Proposed block not proveable", "blockID", event.BlockId, "prover", block.AssignedProver.Hex())
 
-				// if we cant prove it
+				// if we cant prove it now, but config is set to wait and try to prove
+				// expired proofs
 				if p.cfg.ProveExpiredProofs {
 					p.currentBlocksWaitingForProofWindowMutex.Lock()
 					p.currentBlocksWaitingForProofWindow[event.Meta.Id] = event.Raw.BlockNumber

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -862,6 +862,12 @@ func (p *Prover) checkProofWindowExpired(ctx context.Context, l1Height, blockId 
 		}
 
 		if forkChoice.Prover == zeroAddress {
+			log.Info("proof window for proof not assigned to us expired, requesting proof",
+				"blockID",
+				blockId,
+				"l1Height",
+				l1Height,
+			)
 			// we can generate the proof, no proof came in by proof window expiring
 			p.proveNotify <- big.NewInt(int64(l1Height))
 		} else {
@@ -875,6 +881,16 @@ func (p *Prover) checkProofWindowExpired(ctx context.Context, l1Height, blockId 
 			// if the hashes dont match, we can generate proof even though
 			// a proof came in before proofwindow expired.
 			if block.Hash() != forkChoice.BlockHash {
+				log.Info("invalid proof detected while watching for proof window expiration, requesting proof",
+					"blockID",
+					blockId,
+					"l1Height",
+					l1Height,
+					"expectedBlockHash",
+					block.Hash(),
+					"forkChoiceBlockHash",
+					common.Bytes2Hex(forkChoice.BlockHash[:]),
+				)
 				// we can generate the proof, the proof is incorrect since blockHash does not match
 				// the correct one but parentHash/gasUsed are correct.
 				p.proveNotify <- new(big.Int).SetUint64(l1Height)

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -48,6 +48,7 @@ func (s *ProverTestSuite) SetupTest() {
 		Dummy:                           true,
 		MaxConcurrentProvingJobs:        1,
 		CheckProofWindowExpiredInterval: 5 * time.Second,
+		ProveExpiredProofs:              true,
 	})))
 	s.p = p
 	s.cancel = cancel

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -48,7 +48,7 @@ func (s *ProverTestSuite) SetupTest() {
 		Dummy:                           true,
 		MaxConcurrentProvingJobs:        1,
 		CheckProofWindowExpiredInterval: 5 * time.Second,
-		ProveExpiredProofs:              true,
+		ProveUnassignedBlocks:           true,
 	})))
 	s.p = p
 	s.cancel = cancel


### PR DESCRIPTION
this pr adds a flag to the prover, which can determien whether this prover should prove unasigned proofs or not.

unassigned proofs: 
1) one where the proofWindow expires and the assignedprover did not submit a proof on time
2) one where the protocol was out of capacity, and the assignedprover is address(0), which means anyone can submit proof.

This can be useful because if you are proving an unassigned proof, and you get assigned a proof, you will not start generating it until the expired proof is done if you are at proving capacity, and you may potentially be slashed if you are late delivering the proof. So you may want to configure two provers on two different machines, one set to true, one set to false, to ensure you have a prover always working on your assigned proofs.

Also improves logging in these areas which was lacking.