### PR TITLE
feat(pkg): Configurable receipt timeouts

### DIFF
--- a/cmd/flags/common.go
+++ b/cmd/flags/common.go
@@ -100,6 +100,12 @@ var (
 		Usage:    "Timeout in seconds for RPC calls",
 		Category: commonCategory,
 	}
+	WaitReceiptTimeout = &cli.Uint64Flag{
+		Name:     "rpc.waitReceiptTimeout",
+		Usage:    "Timeout in seconds for wait for receipts for RPC transactions",
+		Category: commonCategory,
+		Value:    60,
+	}
 )
 
 // All common flags.
@@ -117,6 +123,7 @@ var CommonFlags = []cli.Flag{
 	BackOffMaxRetrys,
 	BackOffRetryInterval,
 	RPCTimeout,
+	WaitReceiptTimeout,
 }
 
 // MergeFlags merges the given flag slices.

--- a/proposer/config.go
+++ b/proposer/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	BackOffRetryInterval                time.Duration
 	ProposeBlockTxReplacementMultiplier uint64
 	RPCTimeout                          *time.Duration
+	WaitReceiptTimeout                  time.Duration
 }
 
 // NewConfigFromCliContext initializes a Config instance from
@@ -116,5 +117,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		BackOffRetryInterval:                time.Duration(c.Uint64(flags.BackOffRetryInterval.Name)) * time.Second,
 		ProposeBlockTxReplacementMultiplier: proposeBlockTxReplacementMultiplier,
 		RPCTimeout:                          timeout,
+		WaitReceiptTimeout:                  time.Duration(c.Uint64(flags.WaitReceiptTimeout.Name)) * time.Second,
 	}, nil
 }

--- a/proposer/config_test.go
+++ b/proposer/config_test.go
@@ -40,6 +40,7 @@ func (s *ProposerTestSuite) TestNewConfigFromCliContext() {
 		&cli.StringFlag{Name: flags.TxPoolLocals.Name},
 		&cli.Uint64Flag{Name: flags.ProposeBlockTxReplacementMultiplier.Name},
 		&cli.Uint64Flag{Name: flags.RPCTimeout.Name},
+		&cli.Uint64Flag{Name: flags.WaitReceiptTimeout.Name},
 	}
 	app.Action = func(ctx *cli.Context) error {
 		c, err := NewConfigFromCliContext(ctx)
@@ -56,6 +57,7 @@ func (s *ProposerTestSuite) TestNewConfigFromCliContext() {
 		s.Equal(goldenTouchAddress, c.LocalAddresses[0])
 		s.Equal(uint64(5), c.ProposeBlockTxReplacementMultiplier)
 		s.Equal(rpcTimeout, *c.RPCTimeout)
+		s.Equal(10*time.Second, c.WaitReceiptTimeout)
 		s.Nil(new(Proposer).InitFromCli(context.Background(), ctx))
 
 		return err
@@ -74,5 +76,6 @@ func (s *ProposerTestSuite) TestNewConfigFromCliContext() {
 		"-" + flags.TxPoolLocals.Name, goldenTouchAddress.Hex(),
 		"-" + flags.ProposeBlockTxReplacementMultiplier.Name, "5",
 		"-" + flags.RPCTimeout.Name, "5",
+		"-" + flags.WaitReceiptTimeout.Name, "10",
 	}))
 }

--- a/proposer/proposer.go
+++ b/proposer/proposer.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	errNoNewTxs                = errors.New("no new transactions")
-	waitReceiptTimeout         = 1 * time.Minute
 	maxSendProposeBlockTxRetry = 10
 )
 
@@ -64,6 +63,8 @@ type Proposer struct {
 
 	ctx context.Context
 	wg  sync.WaitGroup
+
+	waitReceiptTimeout time.Duration
 }
 
 // New initializes the given proposer instance based on the command line flags.
@@ -91,6 +92,7 @@ func InitFromConfig(ctx context.Context, p *Proposer, cfg *Config) (err error) {
 	p.maxProposedTxListsPerEpoch = cfg.MaxProposedTxListsPerEpoch
 	p.txReplacementTipMultiplier = cfg.ProposeBlockTxReplacementMultiplier
 	p.ctx = ctx
+	p.waitReceiptTimeout = cfg.WaitReceiptTimeout
 
 	// RPC clients
 	if p.rpc, err = rpc.NewClient(p.ctx, &rpc.ClientConfig{
@@ -427,7 +429,7 @@ func (p *Proposer) ProposeTxList(
 		return err
 	}
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, waitReceiptTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, p.waitReceiptTimeout)
 	defer cancel()
 
 	if _, err := rpc.WaitReceipt(ctxWithTimeout, p.rpc.L1, tx); err != nil {

--- a/prover/config.go
+++ b/prover/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	CheckProofWindowExpiredInterval time.Duration
 	ProveUnassignedBlocks           bool
 	RPCTimeout                      *time.Duration
+	WaitReceiptTimeout              time.Duration
 }
 
 // NewConfigFromCliContext creates a new config instance from command line flags.
@@ -136,5 +137,6 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		) * time.Second,
 		ProveUnassignedBlocks: c.Bool(flags.ProveUnassignedBlocks.Name),
 		RPCTimeout:            timeout,
+		WaitReceiptTimeout:    time.Duration(c.Uint64(flags.WaitReceiptTimeout.Name)) * time.Second,
 	}, nil
 }

--- a/prover/config_test.go
+++ b/prover/config_test.go
@@ -27,6 +27,7 @@ var testFlags = []cli.Flag{
 	&cli.Uint64Flag{Name: flags.CheckProofWindowExpiredInterval.Name},
 	&cli.BoolFlag{Name: flags.ProveUnassignedBlocks.Name},
 	&cli.Uint64Flag{Name: flags.RPCTimeout.Name},
+	&cli.Uint64Flag{Name: flags.WaitReceiptTimeout.Name},
 }
 
 func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
@@ -37,6 +38,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 	taikoL1 := os.Getenv("TAIKO_L1_ADDRESS")
 	taikoL2 := os.Getenv("TAIKO_L2_ADDRESS")
 	taikoProverPoolL1 := os.Getenv("TAIKO_PROVER_POOL_L1_ADDRESS")
+	waitReceiptTimeout := 10 * time.Second
 
 	app := cli.NewApp()
 	app.Flags = testFlags
@@ -65,6 +67,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		s.Equal("", c.Graffiti)
 		s.Equal(30*time.Second, c.CheckProofWindowExpiredInterval)
 		s.Equal(true, c.ProveUnassignedBlocks)
+		s.Equal(10*time.Second, c.WaitReceiptTimeout)
 		s.Nil(c.RPCTimeout)
 		s.Nil(new(Prover).InitFromCli(context.Background(), ctx))
 
@@ -88,6 +91,7 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 		"-" + flags.Graffiti.Name, "",
 		"-" + flags.CheckProofWindowExpiredInterval.Name, "30",
 		"-" + flags.ProveUnassignedBlocks.Name, "true",
+		"-" + flags.WaitReceiptTimeout.Name, "10",
 	}))
 }
 
@@ -123,5 +127,6 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProverError() {
 		"-" + flags.OracleProver.Name,
 		"-" + flags.Graffiti.Name, "",
 		"-" + flags.RPCTimeout.Name, "5",
+		"-" + flags.WaitReceiptTimeout.Name, "10",
 	}), "oracleProver flag set without oracleProverPrivateKey set")
 }

--- a/prover/config_test.go
+++ b/prover/config_test.go
@@ -38,7 +38,6 @@ func (s *ProverTestSuite) TestNewConfigFromCliContext_OracleProver() {
 	taikoL1 := os.Getenv("TAIKO_L1_ADDRESS")
 	taikoL2 := os.Getenv("TAIKO_L2_ADDRESS")
 	taikoProverPoolL1 := os.Getenv("TAIKO_PROVER_POOL_L1_ADDRESS")
-	waitReceiptTimeout := 10 * time.Second
 
 	app := cli.NewApp()
 	app.Flags = testFlags

--- a/prover/proof_submitter/valid_proof_submitter.go
+++ b/prover/proof_submitter/valid_proof_submitter.go
@@ -42,6 +42,7 @@ type ValidProofSubmitter struct {
 	graffiti           [32]byte
 	submissionMaxRetry uint64
 	retryInterval      time.Duration
+	waitReceiptTimeout time.Duration
 }
 
 // NewValidProofSubmitter creates a new ValidProofSubmitter instance.
@@ -56,6 +57,7 @@ func NewValidProofSubmitter(
 	graffiti string,
 	submissionMaxRetry uint64,
 	retryInterval time.Duration,
+	waitReceiptTimeout time.Duration,
 ) (*ValidProofSubmitter, error) {
 	anchorValidator, err := anchorTxValidator.New(taikoL2Address, rpcClient.L2ChainID, rpcClient)
 	if err != nil {
@@ -87,6 +89,7 @@ func NewValidProofSubmitter(
 		graffiti:           rpc.StringToBytes32(graffiti),
 		submissionMaxRetry: submissionMaxRetry,
 		retryInterval:      retryInterval,
+		waitReceiptTimeout: waitReceiptTimeout,
 	}, nil
 }
 
@@ -271,6 +274,7 @@ func (s *ValidProofSubmitter) SubmitProof(
 		sendTx,
 		s.retryInterval,
 		maxRetry,
+		s.waitReceiptTimeout,
 	); err != nil {
 		if errors.Is(err, errUnretryable) {
 			return nil

--- a/prover/proof_submitter/valid_proof_submitter_test.go
+++ b/prover/proof_submitter/valid_proof_submitter_test.go
@@ -50,6 +50,7 @@ func (s *ProofSubmitterTestSuite) SetupTest() {
 		"test",
 		1,
 		12*time.Second,
+		10*time.Second,
 	)
 	s.Nil(err)
 


### PR DESCRIPTION
When network is busy, 1 minute is not long enough to wait for a receipt, user should be able to config.