### PR TITLE
chore(ci): bump Golang version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git make
 


### PR DESCRIPTION
```
#18 117.9 note: module requires Go 1.19
#18 118.1 make: *** [Makefile:10: build] Error 2
#18 ERROR: process "/bin/sh -c make build" did not complete successfully: exit code: 2
```