### PR TITLE
chore(prover): replace emoji in log message

### DIFF
--- a/prover/proof_submitter/util.go
+++ b/prover/proof_submitter/util.go
@@ -30,7 +30,7 @@ func isSubmitProofTxErrorRetryable(err error, blockID *big.Int) bool {
 		return true
 	}
 
-	log.Warn("🤷‍♂️ Unretryable proof submission error", "error", err, "blockID", blockID)
+	log.Warn("🤷 Unretryable proof submission error", "error", err, "blockID", blockID)
 	return false
 }
 


### PR DESCRIPTION
This pull request just replaces 🤷‍♂️ with 🤷 in the log messages.

Depending on the environment, 🤷‍♂️ is not displayed properly because it consists of 4 code points.

| Code point | Character | Name |
| :---: | :---: | :---: |
|  U+1F937 | 🤷 | Shrug |
| U+200D | | Zero Width Joiner (ZWJ) |
| U+2642 | ♂ | Male Sign |
| U+FE0F | ◌️ | Variation Selector-16 (VS16) |

On iTerm2 on macOS, it is displayed as `🤷\u200d♂️`.

From the perspective of gender equality, it would be better to use the neutral one.