### PR TITLE
fix(prover): fix `maxRetry` configuration when submitting proofs

### DIFF
--- a/prover/proof_submitter/util.go
+++ b/prover/proof_submitter/util.go
@@ -137,6 +137,10 @@ func sendTxWithBackoff(
 
 		return nil
 	}, backOffPolicy); err != nil {
+		if maxRetry != nil {
+			log.Error("Failed to send TaikoL1.proveBlock transaction", "error", err, "maxRetry", *maxRetry)
+			return errUnretryable
+		}
 		return fmt.Errorf("failed to send TaikoL1.proveBlock transaction: %w", err)
 	}
 


### PR DESCRIPTION
We should not return an error when hitting the `maxRetry` （`--proofSubmissionMaxRetry`） config, otherwise, it will still be retried by the main proof submission loop, and `--proofSubmissionMaxRetry` flag wont work:
![image](https://github.com/taikoxyz/taiko-client/assets/104078303/42bf0f6b-4d90-44cc-9884-f90bdb44bae9)
