### PR TITLE
chore(repo): Add Solc Download Check Suite for PlonkVerifier Compilation

### DIFF
--- a/integration_test/nodes/init.sh
+++ b/integration_test/nodes/init.sh
@@ -56,8 +56,6 @@ L2_GENESIS_HASH=$(
         localhost:28545 | jq .result.hash | sed 's/\"//g'
 )
 
-
-
 # Deploy Taiko protocol.
 cd $TAIKO_MONO_DIR/packages/protocol &&
     PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \

--- a/integration_test/nodes/init.sh
+++ b/integration_test/nodes/init.sh
@@ -7,7 +7,9 @@ DIR=$(
     pwd
 )
 
+# Download solc for PlonkVerifier
 $TAIKO_MONO_DIR/packages/protocol/script/download_solc.sh
+
 echo "Starting testnet..."
 
 docker compose -f $TESTNET_CONFIG down -v --remove-orphans &>/dev/null

--- a/integration_test/nodes/init.sh
+++ b/integration_test/nodes/init.sh
@@ -7,6 +7,29 @@ DIR=$(
     pwd
 )
 
+# Download solc for PlonkVerifier
+protocol_dir=$TAIKO_MONO_DIR/packages/protocol
+solc_bin=${protocol_dir}/bin/solc
+
+if [ -f "${solc_bin}" ]; then
+  echo "solc already exists, skipping download."
+else
+  mkdir -p "$(dirname ${solc_bin})"
+  VERSION=v0.8.18
+
+  if [ "$(uname)" = 'Darwin' ]; then
+    SOLC_FILE_NAME=solc-macos
+  elif [ "$(uname)" = 'Linux' ]; then
+    SOLC_FILE_NAME=solc-static-linux
+  else
+    echo "unsupported platform $(uname)"
+    exit 1
+  fi
+
+  wget -O "${solc_bin}" https://github.com/ethereum/solidity/releases/download/$VERSION/$SOLC_FILE_NAME
+  chmod +x "${solc_bin}"
+fi
+
 echo "Starting testnet..."
 
 docker compose -f $TESTNET_CONFIG down -v --remove-orphans &>/dev/null
@@ -32,6 +55,8 @@ L2_GENESIS_HASH=$(
         -d '{"jsonrpc":"2.0","id":0,"method":"eth_getBlockByNumber","params":["0x0", false]}' \
         localhost:28545 | jq .result.hash | sed 's/\"//g'
 )
+
+
 
 # Deploy Taiko protocol.
 cd $TAIKO_MONO_DIR/packages/protocol &&

--- a/integration_test/nodes/init.sh
+++ b/integration_test/nodes/init.sh
@@ -7,29 +7,7 @@ DIR=$(
     pwd
 )
 
-# Download solc for PlonkVerifier
-protocol_dir=$TAIKO_MONO_DIR/packages/protocol
-solc_bin=${protocol_dir}/bin/solc
-
-if [ -f "${solc_bin}" ]; then
-  echo "solc already exists, skipping download."
-else
-  mkdir -p "$(dirname ${solc_bin})"
-  VERSION=v0.8.18
-
-  if [ "$(uname)" = 'Darwin' ]; then
-    SOLC_FILE_NAME=solc-macos
-  elif [ "$(uname)" = 'Linux' ]; then
-    SOLC_FILE_NAME=solc-static-linux
-  else
-    echo "unsupported platform $(uname)"
-    exit 1
-  fi
-
-  wget -O "${solc_bin}" https://github.com/ethereum/solidity/releases/download/$VERSION/$SOLC_FILE_NAME
-  chmod +x "${solc_bin}"
-fi
-
+$TAIKO_MONO_DIR/packages/protocol/script/download_solc.sh
 echo "Starting testnet..."
 
 docker compose -f $TESTNET_CONFIG down -v --remove-orphans &>/dev/null


### PR DESCRIPTION
Before running make test for the first time, switching directories to run the solc installation script after running pnpm install in the protocol directory of taiko-mono can be cumbersome. This change incorporates that step directly into init.sh for convenience.
Before running the forge deployment during make test, check if the PLONK-specific solc compiler is successfully downloaded