### PR TITLE
feat(prover): check `transition.blockHash` before proof generation

### DIFF
--- a/pkg/rpc/utils.go
+++ b/pkg/rpc/utils.go
@@ -166,6 +166,20 @@ func NeedNewProof(
 		return true, nil
 	}
 
+	l1Origin, err := cli.WaitL1Origin(ctxWithTimeout, id)
+	if err != nil {
+		return false, err
+	}
+
+	if l1Origin.L2BlockHash != transition.BlockHash {
+		log.Info(
+			"Different blockhash detected, try submitting a proof",
+			"local", common.BytesToHash(l1Origin.L2BlockHash[:]),
+			"protocol", common.BytesToHash(transition.BlockHash[:]),
+		)
+		return true, nil
+	}
+
 	if proverAddress == transition.Prover {
 		log.Info("📬 Block's proof has already been submitted by current prover", "blockID", id)
 		return false, nil

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -460,20 +460,18 @@ func (p *Prover) onBlockProposed(
 		}
 
 		// Check whether the block's proof is still needed.
-		if !p.cfg.OracleProver {
-			needNewProof, err := rpc.NeedNewProof(
-				p.ctx,
-				p.rpc,
-				event.BlockId,
-				p.proverAddress,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to check whether the L2 block needs a new proof: %w", err)
-			}
+		needNewProof, err := rpc.NeedNewProof(
+			p.ctx,
+			p.rpc,
+			event.BlockId,
+			p.proverAddress,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to check whether the L2 block needs a new proof: %w", err)
+		}
 
-			if !needNewProof {
-				return nil
-			}
+		if !needNewProof {
+			return nil
 		}
 
 		// Check if the current prover has seen this block ID before, there was probably


### PR DESCRIPTION
If there is a `transition` in protocol with same `blockHash`, then there is no need to generate a proof again.