### PR TITLE
feat(prover): increase the assignment expiration waiting time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main,update-expired-time]
+    branches: [main]
     tags:
       - "v*"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: "Push docker image to GCR"
 
 on:
   push:
-    branches: [main]
+    branches: [main,update-expired-time]
     tags:
       - "v*"
 

--- a/driver/chain_syncer/calldata/syncer.go
+++ b/driver/chain_syncer/calldata/syncer.go
@@ -199,10 +199,10 @@ func (s *Syncer) onBlockProposed(
 
 	log.Info(
 		"New BlockProposed event",
-		"L1Height", event.Raw.BlockNumber,
-		"L1Hash", event.Raw.BlockHash,
-		"BlockID", event.BlockId,
-		"Removed", event.Raw.Removed,
+		"l1Height", event.Raw.BlockNumber,
+		"l1Hash", event.Raw.BlockHash,
+		"blockID", event.BlockId,
+		"removed", event.Raw.Removed,
 	)
 
 	// Fetch the L2 parent block.

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -532,8 +532,14 @@ func (p *Prover) onBlockProposed(
 
 				if p.cfg.ProveUnassignedBlocks {
 					log.Info(
-						"Add proposed block to wait for proof window expiration", "blockID", event.BlockId)
-					time.AfterFunc(timeToExpire+12*time.Second, func() { p.proofWindowExpiredCh <- event })
+						"Add proposed block to wait for proof window expiration",
+						"blockID", event.BlockId,
+					)
+					time.AfterFunc(
+						// Add another 12 seconds, to ensure one more L1 block will be mined before the proof submission
+						timeToExpire+12*time.Second,
+						func() { p.proofWindowExpiredCh <- event },
+					)
 				}
 
 				return nil

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -424,7 +424,7 @@ func (p *Prover) onBlockProposed(
 			"L1 block hash mismatch due to L1 reorg",
 			"height", event.Meta.L1Height,
 			"currentL1OriginHeader", currentL1OriginHeader.Hash(),
-			"L1HashInEvent", event.Meta.L1Hash,
+			"l1HashInEvent", event.Meta.L1Hash,
 		)
 
 		return fmt.Errorf(

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -436,10 +436,10 @@ func (p *Prover) onBlockProposed(
 
 	log.Info(
 		"Proposed block",
-		"L1Height", event.Raw.BlockNumber,
-		"L1Hash", event.Raw.BlockHash,
-		"BlockID", event.BlockId,
-		"Removed", event.Raw.Removed,
+		"l1Height", event.Raw.BlockNumber,
+		"l1Hash", event.Raw.BlockHash,
+		"blockID", event.BlockId,
+		"removed", event.Raw.Removed,
 	)
 	metrics.ProverReceivedProposedBlockGauge.Update(event.BlockId.Int64())
 
@@ -531,8 +531,9 @@ func (p *Prover) onBlockProposed(
 				)
 
 				if p.cfg.ProveUnassignedBlocks {
-					log.Info("Add proposed block to wait for proof window expiration", "blockID", event.BlockId)
-					time.AfterFunc(timeToExpire, func() { p.proofWindowExpiredCh <- event })
+					log.Info(
+						"Add proposed block to wait for proof window expiration", "blockID", event.BlockId)
+					time.AfterFunc(timeToExpire+12*time.Second, func() { p.proofWindowExpiredCh <- event })
 				}
 
 				return nil


### PR DESCRIPTION
Add another 12 seconds, to ensure another L1 block will be mined before the proof submission