### PR TITLE
feat(prover): improve `/status` API

### DIFF
--- a/prover/server/api.go
+++ b/prover/server/api.go
@@ -39,8 +39,8 @@ type Status struct {
 	MinPseZkevmTierFee   uint64 `json:"minPseZkevmTierFee"`
 	MaxExpiry            uint64 `json:"maxExpiry"`
 	CurrentCapacity      uint64 `json:"currentCapacity"`
-	ProverAddress        string `json:"proverAddress"`
-	HeartBeatSignature   string `json:"heartBeatSignature"`
+	Prover               string `json:"prover"`
+	HeartBeatSignature   []byte `json:"heartBeatSignature"`
 }
 
 // GetStatus handles a query to the current prover server status.
@@ -63,8 +63,8 @@ func (srv *ProverServer) GetStatus(c echo.Context) error {
 		MinPseZkevmTierFee:   srv.minPseZkevmTierFee.Uint64(),
 		MaxExpiry:            uint64(srv.maxExpiry.Seconds()),
 		CurrentCapacity:      srv.capacityManager.ReadCapacity(),
-		ProverAddress:        srv.proverAddress.Hex(),
-		HeartBeatSignature:   common.Bytes2Hex(sig),
+		Prover:               srv.proverAddress.Hex(),
+		HeartBeatSignature:   sig,
 	})
 }
 

--- a/prover/server/api.go
+++ b/prover/server/api.go
@@ -39,6 +39,8 @@ type Status struct {
 	MinPseZkevmTierFee   uint64 `json:"minPseZkevmTierFee"`
 	MaxExpiry            uint64 `json:"maxExpiry"`
 	CurrentCapacity      uint64 `json:"currentCapacity"`
+	ProverAddress        string `json:"proverAddress"`
+	HeartBeatSignature   string `json:"heartBeatSignature"`
 }
 
 // GetStatus handles a query to the current prover server status.
@@ -50,12 +52,19 @@ type Status struct {
 //	@Success		200	{object} Status
 //	@Router			/status [get]
 func (srv *ProverServer) GetStatus(c echo.Context) error {
+	sig, err := crypto.Sign(crypto.Keccak256Hash([]byte("HEART_BEAT")).Bytes(), srv.proverPrivateKey)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+
 	return c.JSON(http.StatusOK, &Status{
 		MinOptimisticTierFee: srv.minOptimisticTierFee.Uint64(),
 		MinSgxTierFee:        srv.minSgxTierFee.Uint64(),
 		MinPseZkevmTierFee:   srv.minPseZkevmTierFee.Uint64(),
 		MaxExpiry:            uint64(srv.maxExpiry.Seconds()),
 		CurrentCapacity:      srv.capacityManager.ReadCapacity(),
+		ProverAddress:        srv.proverAddress.Hex(),
+		HeartBeatSignature:   common.Bytes2Hex(sig),
 	})
 }
 

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -29,10 +29,10 @@ func (s *ProverServerTestSuite) TestGetStatusSuccess() {
 	s.Equal(uint64(s.s.maxExpiry.Seconds()), status.MaxExpiry)
 	s.Greater(status.CurrentCapacity, uint64(0))
 	s.NotEmpty(status.HeartBeatSignature)
-	pubKey, err := crypto.SigToPub([]byte("HEART_BEAT"), common.Hex2Bytes(status.HeartBeatSignature))
+	pubKey, err := crypto.SigToPub(crypto.Keccak256Hash([]byte("HEART_BEAT")).Bytes(), status.HeartBeatSignature)
 	s.Nil(err)
-	s.NotEmpty(status.ProverAddress)
-	s.Equal(status.ProverAddress, crypto.PubkeyToAddress(*pubKey).Hex())
+	s.NotEmpty(status.Prover)
+	s.Equal(status.Prover, crypto.PubkeyToAddress(*pubKey).Hex())
 }
 
 func (s *ProverServerTestSuite) TestProposeBlockSuccess() {

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/taikoxyz/taiko-client/bindings/encoding"
 )
 
@@ -27,6 +28,11 @@ func (s *ProverServerTestSuite) TestGetStatusSuccess() {
 	s.Equal(s.s.minSgxAndPseZkevmTierFee.Uint64(), status.MinSgxTierFee)
 	s.Equal(uint64(s.s.maxExpiry.Seconds()), status.MaxExpiry)
 	s.Greater(status.CurrentCapacity, uint64(0))
+	s.NotEmpty(status.HeartBeatSignature)
+	pubKey, err := crypto.SigToPub([]byte("HEART_BEAT"), common.Hex2Bytes(status.HeartBeatSignature))
+	s.Nil(err)
+	s.NotEmpty(status.ProverAddress)
+	s.Equal(status.ProverAddress, crypto.PubkeyToAddress(*pubKey).Hex())
 }
 
 func (s *ProverServerTestSuite) TestProposeBlockSuccess() {


### PR DESCRIPTION
Those two fields will be used by the new guardian prover dashboard.