### PR TITLE
chore(pkg): Update fallback.go - Fix broken link

### DIFF
--- a/pkg/rpc/fallback.go
+++ b/pkg/rpc/fallback.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 )
 
-// Taken from https://github.com/ethereum-optimism/optimism-legacy/blob/develop/bss-core/drivers/max_priority_fee_fallback.go
+// Taken from: 
+// https://github.com/ethereum-optimism/optimism-legacy/blob/develop/bss-core/drivers/max_priority_fee_fallback.go
 var (
 	//lint:ignore ST1005 allow `errMaxPriorityFeePerGasNotFound` to be capitalized.
 	errMaxPriorityFeePerGasNotFound = errors.New(

--- a/pkg/rpc/fallback.go
+++ b/pkg/rpc/fallback.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Taken from https://github.com/ethereum-optimism/optimism/blob/develop/bss-core/drivers/max_priority_fee_fallback.go
+// Taken from https://github.com/ethereum-optimism/optimism-legacy/blob/develop/bss-core/drivers/max_priority_fee_fallback.go
 var (
 	//lint:ignore ST1005 allow `errMaxPriorityFeePerGasNotFound` to be capitalized.
 	errMaxPriorityFeePerGasNotFound = errors.New(


### PR DESCRIPTION
Old: https://github.com/ethereum-optimism/optimism/blob/develop/bss-core/drivers/max_priority_fee_fallback.go

New: https://github.com/ethereum-optimism/optimism-legacy/blob/develop/bss-core/drivers/max_priority_fee_fallback.go