### PR TITLE
fix(prover): Guardian prover sign wait

### DIFF
--- a/prover/prover.go
+++ b/prover/prover.go
@@ -229,7 +229,7 @@ func InitFromConfig(ctx context.Context, p *Prover, cfg *Config) (err error) {
 	// levelDB
 	var db ethdb.KeyValueStore
 	if cfg.DatabasePath != "" {
-		db, err := leveldb.New(cfg.DatabasePath, int(cfg.DatabaseCacheSize), 1, "taiko", false)
+		db, err = leveldb.New(cfg.DatabasePath, int(cfg.DatabaseCacheSize), 1, "taiko", false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
wait for chain head to have block before trying to sign. THis is perhaps a temporary fix as there should be a secondary mechanism for guardian prover signing blocks, perhaps with its own `blockProposedCh` and own iterators, that way it doesnt exist alongside proving code.

I will do a further PR for a `GuardianProverSigner` struct that embeds in the Prover, and has its own event loop, after the weekend, if we want to go that route.