### PR TITLE
feat(proposer): optimze log

### DIFF
--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -99,7 +99,7 @@ func (c *Client) WaitTillL2ExecutionEngineSynced(ctx context.Context) error {
 			}
 
 			if progress.isSyncing() {
-				log.Info("L2 execution engine is syncing",  "CurrentBlockID",progress.CurrentBlockID, "HighestBlockID", progress.HighestBlockID, "progress", progress.SyncProgress,)
+				log.Info("L2 execution engine is syncing", "CurrentBlockID", progress.CurrentBlockID, "HighestBlockID", progress.HighestBlockID, "progress", progress.SyncProgress)
 				return errSyncing
 			}
 

--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -99,7 +99,8 @@ func (c *Client) WaitTillL2ExecutionEngineSynced(ctx context.Context) error {
 			}
 
 			if progress.isSyncing() {
-				log.Info("L2 execution engine is syncing", "CurrentBlockID", progress.CurrentBlockID, "HighestBlockID", progress.HighestBlockID, "progress", progress.SyncProgress)
+				log.Info("L2 execution engine is syncing", "CurrentBlockID", progress.CurrentBlockID,
+					"HighestBlockID", progress.HighestBlockID, "progress", progress.SyncProgress)
 				return errSyncing
 			}
 

--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -99,7 +99,7 @@ func (c *Client) WaitTillL2ExecutionEngineSynced(ctx context.Context) error {
 			}
 
 			if progress.isSyncing() {
-				log.Info("L2 execution engine is syncing", "progress", progress)
+				log.Info("L2 execution engine is syncing",  "CurrentBlockID",progress.CurrentBlockID, "HighestBlockID", progress.HighestBlockID, "progress", progress.SyncProgress,)
 				return errSyncing
 			}
 


### PR DESCRIPTION
Currently, when L2 execution engine is syncing, proposer logs are like:
```
taiko_client_proposer_1  | INFO [12-05|10:31:57.800] L2 execution engine is syncing           progress="&{SyncProgress:0xc0000d07e0 CurrentBlockID:+1356428 HighestBlockID:+1453513}"
taiko_client_proposer_1  | INFO [12-05|10:32:10.073] L2 execution engine is syncing           progress="&{SyncProgress:0xc0000d0900 CurrentBlockID:+1356428 HighestBlockID:+1453513}"
taiko_client_proposer_1  | INFO [12-05|10:32:22.345] L2 execution engine is syncing           progress="&{SyncProgress:0xc0000d03f0 CurrentBlockID:+1356428 HighestBlockID:+1453517}"
taiko_client_proposer_1  | INFO [12-05|10:32:34.619] L2 execution engine is syncing           progress="&{SyncProgress:0xc00036b710 CurrentBlockID:+1356428 HighestBlockID:+1453520}"
```
The `progress` field don't have useful information. This PR enhance the log to provide more details.
The log will be like:
```
taiko_client_proposer_1  | INFO [12-06|02:36:33.600] L2 execution engine is syncing           CurrentBlockID=1,356,428 HighestBlockID=1,464,417 progress="&{StartingBlock:1447613 CurrentBlock:1452990 HighestBlock:1463134 PulledStates:0 KnownStates:0 SyncedAccounts:0 SyncedAccountBytes:0 SyncedBytecodes:0 SyncedBytecodeBytes:0 SyncedStorage:0 SyncedStorageBytes:0 HealedTrienodes:0 HealedTrienodeBytes:0 HealedBytecodes:0 HealedBytecodeBytes:0 HealingTrienodes:0 HealingBytecode:0}"
taiko_client_proposer_1  | INFO [12-06|02:36:45.857] L2 execution engine is syncing           CurrentBlockID=1,356,428 HighestBlockID=1,464,418 progress="&{StartingBlock:1447613 CurrentBlock:1453344 HighestBlock:1463134 PulledStates:0 KnownStates:0 SyncedAccounts:0 SyncedAccountBytes:0 SyncedBytecodes:0 SyncedBytecodeBytes:0 SyncedStorage:0 SyncedStorageBytes:0 HealedTrienodes:0 HealedTrienodeBytes:0 HealedBytecodes:0 HealedBytecodeBytes:0 HealingTrienodes:0 HealingBytecode:0}"
taiko_client_proposer_1  | INFO [12-06|02:36:58.110] L2 execution engine is syncing           CurrentBlockID=1,356,428 HighestBlockID=1,464,420 progress="&{StartingBlock:1447613 CurrentBlock:1453702 HighestBlock:1463134 PulledStates:0 KnownStates:0 SyncedAccounts:0 SyncedAccountBytes:0 SyncedBytecodes:0 SyncedBytecodeBytes:0 SyncedStorage:0 SyncedStorageBytes:0 HealedTrienodes:0 HealedTrienodeBytes:0 HealedBytecodes:0 HealedBytecodeBytes:0 HealingTrienodes:0 HealingBytecode:0}"
```