### PR TITLE
feat(prover): change block signing to use timestamp as key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: taikoxyz/taiko-mono
           path: ${{ env.TAIKO_MONO_DIR }}
-          ref: based_contestable_zkrollup_improved
+          ref: based_contestable_zkrollup
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -19,10 +19,11 @@ func BuildBlockKey(blockTimestamp uint64) []byte {
 }
 
 // BuildBlockValue will build a block value for a signed block
-func BuildBlockValue(hash []byte, signature []byte) []byte {
+func BuildBlockValue(hash []byte, signature []byte, blockID uint64) []byte {
 	return bytes.Join(
 		[][]byte{
 			hash,
 			signature,
+			[]byte(strconv.Itoa(int(blockID))),
 		}, []byte("-"))
 }

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -6,6 +6,6 @@ var (
 	BlockKeyPrefix = "blockid-"
 )
 
-func BuildBlockKey(blockID string) []byte {
-	return []byte(fmt.Sprintf("%v%v", BlockKeyPrefix, blockID))
+func BuildBlockKey(blockTimestamp uint64) []byte {
+	return []byte(fmt.Sprintf("%v%v", BlockKeyPrefix, blockTimestamp))
 }

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	BlockKeyPrefix = "blockid-"
+	BlockKeyPrefix = "block-"
 )
 
 // BuildBlockKey will build a block key for a signed block

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -10,10 +10,17 @@ var (
 )
 
 func BuildBlockKey(blockTimestamp uint64) []byte {
-	strconv.Itoa(int(blockTimestamp))
 	return bytes.Join(
 		[][]byte{
 			[]byte(BlockKeyPrefix),
 			[]byte(strconv.Itoa(int(blockTimestamp))),
 		}, []byte{})
+}
+
+func BuildBlockValue(hash []byte, signature []byte) []byte {
+	return bytes.Join(
+		[][]byte{
+			hash,
+			signature,
+		}, []byte("-"))
 }

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -9,6 +9,7 @@ var (
 	BlockKeyPrefix = "blockid-"
 )
 
+// BuildBlockKey will build a block key for a signed block
 func BuildBlockKey(blockTimestamp uint64) []byte {
 	return bytes.Join(
 		[][]byte{
@@ -17,6 +18,7 @@ func BuildBlockKey(blockTimestamp uint64) []byte {
 		}, []byte{})
 }
 
+// BuildBlockValue will build a block value for a signed block
 func BuildBlockValue(hash []byte, signature []byte) []byte {
 	return bytes.Join(
 		[][]byte{

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -2,12 +2,21 @@ package db
 
 import (
 	"bytes"
+	"math/big"
 	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
 	BlockKeyPrefix = "block-"
 )
+
+type SignedBlockData struct {
+	BlockID   *big.Int
+	BlockHash common.Hash
+	Signature string
+}
 
 // BuildBlockKey will build a block key for a signed block
 func BuildBlockKey(blockTimestamp uint64) []byte {
@@ -19,11 +28,21 @@ func BuildBlockKey(blockTimestamp uint64) []byte {
 }
 
 // BuildBlockValue will build a block value for a signed block
-func BuildBlockValue(hash []byte, signature []byte, blockID uint64) []byte {
+func BuildBlockValue(hash []byte, signature []byte, blockID *big.Int) []byte {
 	return bytes.Join(
 		[][]byte{
 			hash,
 			signature,
-			[]byte(strconv.Itoa(int(blockID))),
+			blockID.Bytes(),
 		}, []byte("-"))
+}
+
+func SignedBlockDataFromValue(val []byte) SignedBlockData {
+	v := bytes.Split(val, []byte("-"))
+
+	return SignedBlockData{
+		BlockID:   new(big.Int).SetBytes(v[2]),
+		BlockHash: common.BytesToHash(v[0]),
+		Signature: common.Bytes2Hex(v[1]),
+	}
 }

--- a/prover/db/db.go
+++ b/prover/db/db.go
@@ -1,11 +1,19 @@
 package db
 
-import "fmt"
+import (
+	"bytes"
+	"strconv"
+)
 
 var (
 	BlockKeyPrefix = "blockid-"
 )
 
 func BuildBlockKey(blockTimestamp uint64) []byte {
-	return []byte(fmt.Sprintf("%v%v", BlockKeyPrefix, blockTimestamp))
+	strconv.Itoa(int(blockTimestamp))
+	return bytes.Join(
+		[][]byte{
+			[]byte(BlockKeyPrefix),
+			[]byte(strconv.Itoa(int(blockTimestamp))),
+		}, []byte{})
 }

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -1,9 +1,11 @@
 package db
 
 import (
-	"strings"
+	"bytes"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,9 +14,22 @@ func Test_BuildBlockKey(t *testing.T) {
 }
 
 func Test_BuildBlockValue(t *testing.T) {
-	v := BuildBlockValue([]byte("hash"), []byte("sig"), 1)
-	spl := strings.Split(string(v), "-")
-	assert.Equal(t, "hash", spl[0])
-	assert.Equal(t, "sig", spl[1])
-	assert.Equal(t, "1", spl[2])
+	v := BuildBlockValue([]byte("hash"), []byte("sig"), big.NewInt(1))
+	spl := bytes.Split(v, []byte("-"))
+	assert.Equal(t, "hash", string(spl[0]))
+	assert.Equal(t, "sig", string(spl[1]))
+	assert.Equal(t, uint64(1), new(big.Int).SetBytes(spl[2]).Uint64())
+}
+
+func Test_SignedBlockDataFromValue(t *testing.T) {
+	hash := common.HexToHash("0x1ada5c5ba58cfca1fbcd4531f4132f8cfef736c2cf40209a1315c489717dfc49")
+	// nolint: lll
+	sig := common.Hex2Bytes("789a80053e4927d0a898db8e065e948f5cf086e32f9ccaa54c1908e22ac430c62621578113ddbb62d509bf6049b8fb544ab06d36f916685a2eb8e57ffadde02301")
+
+	v := BuildBlockValue(hash.Bytes(), sig, big.NewInt(1))
+	data := SignedBlockDataFromValue(v)
+
+	assert.Equal(t, common.Bytes2Hex(sig), data.Signature)
+	assert.Equal(t, hash, data.BlockHash)
+	assert.Equal(t, data.BlockID, big.NewInt(1))
 }

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -12,8 +12,9 @@ func Test_BuildBlockKey(t *testing.T) {
 }
 
 func Test_BuildBlockValue(t *testing.T) {
-	v := BuildBlockValue([]byte("hash"), []byte("sig"))
+	v := BuildBlockValue([]byte("hash"), []byte("sig"), 1)
 	spl := strings.Split(string(v), "-")
 	assert.Equal(t, "hash", spl[0])
 	assert.Equal(t, "sig", spl[1])
+	assert.Equal(t, "1", spl[2])
 }

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -22,7 +22,7 @@ func Test_BuildBlockValue(t *testing.T) {
 }
 
 func Test_SignedBlockDataFromValue(t *testing.T) {
-	hash := common.HexToHash("0x1ada5c5ba58cfca1fbcd4531f4132f8cfef736c2cf40209a1315c489717dfc49")
+	hash := common.HexToHash("1ada5c5ba58cfca1fbcd4531f4132f8cfef736c2cf40209a1315c489717dfc49")
 	// nolint: lll
 	sig := common.Hex2Bytes("789a80053e4927d0a898db8e065e948f5cf086e32f9ccaa54c1908e22ac430c62621578113ddbb62d509bf6049b8fb544ab06d36f916685a2eb8e57ffadde02301")
 

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func Test_BuildBlockKey(t *testing.T) {
-	assert.Equal(t, BuildBlockKey("1"), []byte("blockid-1"))
+	assert.Equal(t, BuildBlockKey(1), []byte("blockid-1"))
 }

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func Test_BuildBlockKey(t *testing.T) {
-	assert.Equal(t, BuildBlockKey(1), []byte("blockid-1"))
+	assert.Equal(t, []byte("block-1"), BuildBlockKey(1))
 }

--- a/prover/db/db_test.go
+++ b/prover/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,4 +9,11 @@ import (
 
 func Test_BuildBlockKey(t *testing.T) {
 	assert.Equal(t, []byte("block-1"), BuildBlockKey(1))
+}
+
+func Test_BuildBlockValue(t *testing.T) {
+	v := BuildBlockValue([]byte("hash"), []byte("sig"))
+	spl := strings.Split(string(v), "-")
+	assert.Equal(t, "hash", spl[0])
+	assert.Equal(t, "sig", spl[1])
 }

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1306,7 +1306,9 @@ func (p *Prover) signBlock(ctx context.Context, blockID *big.Int) error {
 		return err
 	}
 
-	if err := p.db.Put(db.BuildBlockKey(block.Time()), signed); err != nil {
+	val := db.BuildBlockValue(block.Hash().Bytes(), signed)
+
+	if err := p.db.Put(db.BuildBlockKey(block.Time()), val); err != nil {
 		return err
 	}
 

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1263,16 +1263,6 @@ func (p *Prover) signBlock(ctx context.Context, blockID *big.Int) error {
 
 	log.Info("guardian prover signing block", "blockID", blockID.Uint64())
 
-	exists, err := p.db.Has(db.BuildBlockKey(blockID.String()))
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		log.Info("guardian prover already signed block", "blockID", blockID.Uint64())
-		return nil
-	}
-
 	latest, err := p.rpc.L2.BlockByNumber(ctx, nil)
 	if err != nil {
 		return err
@@ -1291,22 +1281,32 @@ func (p *Prover) signBlock(ctx context.Context, blockID *big.Int) error {
 		}
 	}
 
-	log.Info("guardian prover block signing caught up",
-		"latestBlock", latest.Number().Uint64(),
-		"eventBlockID", blockID.Uint64(),
-	)
-
 	block, err := p.rpc.L2.BlockByNumber(ctx, blockID)
 	if err != nil {
 		return err
 	}
+
+	exists, err := p.db.Has(db.BuildBlockKey(block.Time()))
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		log.Info("guardian prover already signed block", "blockID", blockID.Uint64())
+		return nil
+	}
+
+	log.Info("guardian prover block signing caught up",
+		"latestBlock", latest.Number().Uint64(),
+		"eventBlockID", blockID.Uint64(),
+	)
 
 	signed, err := crypto.Sign(block.Hash().Bytes(), p.proverPrivateKey)
 	if err != nil {
 		return err
 	}
 
-	if err := p.db.Put(db.BuildBlockKey(blockID.String()), signed); err != nil {
+	if err := p.db.Put(db.BuildBlockKey(block.Time()), signed); err != nil {
 		return err
 	}
 

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1306,7 +1306,7 @@ func (p *Prover) signBlock(ctx context.Context, blockID *big.Int) error {
 		return err
 	}
 
-	val := db.BuildBlockValue(block.Hash().Bytes(), signed)
+	val := db.BuildBlockValue(block.Hash().Bytes(), signed, blockID.Uint64())
 
 	if err := p.db.Put(db.BuildBlockKey(block.Time()), val); err != nil {
 		return err

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1306,7 +1306,7 @@ func (p *Prover) signBlock(ctx context.Context, blockID *big.Int) error {
 		return err
 	}
 
-	val := db.BuildBlockValue(block.Hash().Bytes(), signed, blockID.Uint64())
+	val := db.BuildBlockValue(block.Hash().Bytes(), signed, blockID)
 
 	if err := p.db.Put(db.BuildBlockKey(block.Time()), val); err != nil {
 		return err

--- a/prover/server/api.go
+++ b/prover/server/api.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -281,18 +280,10 @@ func (srv *ProverServer) GetSignedBlocks(c echo.Context) error {
 	defer iter.Release()
 
 	for iter.Next() {
-		k := strings.Split(string(iter.Key()), "-")
-
-		blockID, err := strconv.Atoi(k[1])
-
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
-		}
-
 		v := bytes.Split(iter.Value(), []byte("-"))
 
 		signedBlocks = append(signedBlocks, SignedBlock{
-			BlockID:   uint64(blockID),
+			BlockID:   new(big.Int).SetBytes(v[2]).Uint64(),
 			BlockHash: common.Bytes2Hex(v[0]),
 			Signature: common.Bytes2Hex(v[1]),
 			Prover:    srv.proverAddress,

--- a/prover/server/api.go
+++ b/prover/server/api.go
@@ -245,6 +245,8 @@ func (srv *ProverServer) GetSignedBlocks(c echo.Context) error {
 		start = c.QueryParam("start")
 	}
 
+	// if no start timestamp was provided, we can get the latest block, and return
+	// defaultNumBlocksToReturn blocks signed before latest, if our guardian prover has signed them.
 	if start == "0" {
 		latestBlock, err := srv.rpc.L2.BlockByNumber(c.Request().Context(), nil)
 		if err != nil {
@@ -271,9 +273,8 @@ func (srv *ProverServer) GetSignedBlocks(c echo.Context) error {
 		}
 	}
 
-	// start should be set to a block timestamp latestBlock-numBlocksToReturn blocks ago.
-	// so when we iterate, we should only be seeing numBlocksToReturn amount of blocks being pulled
-	// from the database and returned.
+	// start should be set to a block timestamp latestBlock-numBlocksToReturn blocks ago if
+	// a start timestamp was not provided.
 
 	iter := srv.db.NewIterator([]byte(db.BlockKeyPrefix), []byte(start))
 

--- a/prover/server/api.go
+++ b/prover/server/api.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -280,12 +279,12 @@ func (srv *ProverServer) GetSignedBlocks(c echo.Context) error {
 	defer iter.Release()
 
 	for iter.Next() {
-		v := bytes.Split(iter.Value(), []byte("-"))
+		signedblockData := db.SignedBlockDataFromValue(iter.Value())
 
 		signedBlocks = append(signedBlocks, SignedBlock{
-			BlockID:   new(big.Int).SetBytes(v[2]).Uint64(),
-			BlockHash: common.Bytes2Hex(v[0]),
-			Signature: common.Bytes2Hex(v[1]),
+			BlockID:   signedblockData.BlockID.Uint64(),
+			BlockHash: signedblockData.BlockHash.Hex(),
+			Signature: signedblockData.Signature,
 			Prover:    srv.proverAddress,
 		})
 	}

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -71,7 +71,7 @@ func (s *ProverServerTestSuite) TestGetSignedBlocks() {
 		s.Nil(err)
 		key := db.BuildBlockKey(bigInt.Uint64())
 
-		val := db.BuildBlockValue(common.BigToHash(bigInt).Bytes(), signed)
+		val := db.BuildBlockValue(common.BigToHash(bigInt).Bytes(), signed, uint64(i))
 
 		s.Nil(s.s.db.Put(key, val))
 		has, err := s.s.db.Has(key)

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -71,7 +71,7 @@ func (s *ProverServerTestSuite) TestGetSignedBlocks() {
 		s.Nil(err)
 		key := db.BuildBlockKey(bigInt.Uint64())
 
-		val := db.BuildBlockValue(common.BigToHash(bigInt).Bytes(), signed, uint64(i))
+		val := db.BuildBlockValue(common.BigToHash(bigInt).Bytes(), signed, big.NewInt(1))
 
 		s.Nil(s.s.db.Put(key, val))
 		has, err := s.s.db.Has(key)

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -65,7 +65,7 @@ func (s *ProverServerTestSuite) TestGetSignedBlocks() {
 	signed, err := crypto.Sign(latest.Hash().Bytes(), s.s.proverPrivateKey)
 	s.Nil(err)
 
-	s.Nil(s.s.db.Put(db.BuildBlockKey(latest.Number().String()), signed))
+	s.Nil(s.s.db.Put(db.BuildBlockKey(latest.Time()), signed))
 	res := s.sendReq("/signedBlocks")
 	s.Equal(http.StatusOK, res.StatusCode)
 

--- a/prover/server/api_test.go
+++ b/prover/server/api_test.go
@@ -71,7 +71,9 @@ func (s *ProverServerTestSuite) TestGetSignedBlocks() {
 		s.Nil(err)
 		key := db.BuildBlockKey(bigInt.Uint64())
 
-		s.Nil(s.s.db.Put(key, signed))
+		val := db.BuildBlockValue(common.BigToHash(bigInt).Bytes(), signed)
+
+		s.Nil(s.s.db.Put(key, val))
 		has, err := s.s.db.Has(key)
 		s.Nil(err)
 		s.True(has)

--- a/prover/server/server.go
+++ b/prover/server/server.go
@@ -17,6 +17,10 @@ import (
 	capacity "github.com/taikoxyz/taiko-client/prover/capacity_manager"
 )
 
+var (
+	defaultNumBlocksToReturn = new(big.Int).SetUint64(100)
+)
+
 // @title Taiko Prover API
 // @version 1.0
 // @termsOfService http://swagger.io/terms/

--- a/prover/server/server.go
+++ b/prover/server/server.go
@@ -17,10 +17,6 @@ import (
 	capacity "github.com/taikoxyz/taiko-client/prover/capacity_manager"
 )
 
-var (
-	numBlocksToReturn = new(big.Int).SetUint64(200)
-)
-
 // @title Taiko Prover API
 // @version 1.0
 // @termsOfService http://swagger.io/terms/


### PR DESCRIPTION
key previously used block ID which made it difficult to iterate using the DB iterator, because key prefixes would be like `blockid-1, blockid-100` instead of something like `blockid-1, blockid-2`.

also fixes issue where all block hashes were using `latestBlock`, we now store the block hash as part of the value.

adds a more comprehensive test as well.