### PR TITLE
feat(bindings): update `AssigmentHook` signing based on protocol updates

### DIFF
--- a/bindings/encoding/input.go
+++ b/bindings/encoding/input.go
@@ -169,6 +169,10 @@ var (
 			Type: "bytes32",
 		},
 		{
+			Name: "parentMetaHash",
+			Type: "bytes32",
+		},
+		{
 			Name: "tierFees",
 			Type: "tuple[]",
 			Components: []abi.ArgumentMarshaling{
@@ -246,6 +250,7 @@ var (
 		{Name: "taikoAddress", Type: addressType},
 		{Name: "assignmentHookAddress", Type: addressType},
 		{Name: "metaHash", Type: bytes32Type},
+		{Name: "parentMetaHash", Type: bytes32Type},
 		{Name: "blobHash", Type: bytes32Type},
 		{Name: "assignment.feeToken", Type: addressType},
 		{Name: "assignment.expiry", Type: uint64Type},
@@ -334,6 +339,7 @@ func EncodeProverAssignmentPayload(
 		chainID,
 		taikoAddress,
 		assignmentHookAddress,
+		common.Hash{},
 		common.Hash{},
 		txListHash,
 		feeToken,

--- a/bindings/encoding/struct.go
+++ b/bindings/encoding/struct.go
@@ -65,13 +65,14 @@ type TierFee struct {
 
 // ProverAssignment should be same with TaikoData.ProverAssignment.
 type ProverAssignment struct {
-	FeeToken      common.Address
-	Expiry        uint64
-	MaxBlockId    uint64 // nolint: revive,stylecheck
-	MaxProposedIn uint64
-	MetaHash      [32]byte
-	TierFees      []TierFee
-	Signature     []byte
+	FeeToken       common.Address
+	Expiry         uint64
+	MaxBlockId     uint64 // nolint: revive,stylecheck
+	MaxProposedIn  uint64
+	MetaHash       [32]byte
+	ParentMetaHash [32]byte
+	TierFees       []TierFee
+	Signature      []byte
 }
 
 // AssignmentHookInput should be same as AssignmentHook.Input


### PR DESCRIPTION
This commit should not be merged into `alpha-6` branch, only keep it in `main`.

Ref: https://github.com/taikoxyz/taiko-mono/pull/15498