### PR TITLE
refactor(driver): rename `calldataSyncer` to `blobSyncer`

### DIFF
--- a/driver/chain_syncer/blob/syncer.go
+++ b/driver/chain_syncer/blob/syncer.go
@@ -1,4 +1,4 @@
-package calldata
+package blob
 
 import (
 	"context"

--- a/driver/chain_syncer/blob/syncer_test.go
+++ b/driver/chain_syncer/blob/syncer_test.go
@@ -1,4 +1,4 @@
-package calldata
+package blob
 
 import (
 	"context"
@@ -23,13 +23,13 @@ import (
 	"github.com/taikoxyz/taiko-client/proposer"
 )
 
-type CalldataSyncerTestSuite struct {
+type BlobSyncerTestSuite struct {
 	testutils.ClientTestSuite
 	s *Syncer
 	p testutils.Proposer
 }
 
-func (s *CalldataSyncerTestSuite) SetupTest() {
+func (s *BlobSyncerTestSuite) SetupTest() {
 	s.ClientTestSuite.SetupTest()
 
 	state2, err := state.New(context.Background(), s.RPCClient)
@@ -48,7 +48,7 @@ func (s *CalldataSyncerTestSuite) SetupTest() {
 
 	s.initProposer()
 }
-func (s *CalldataSyncerTestSuite) TestCancelNewSyncer() {
+func (s *BlobSyncerTestSuite) TestCancelNewSyncer() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	syncer, err := NewSyncer(
@@ -63,16 +63,16 @@ func (s *CalldataSyncerTestSuite) TestCancelNewSyncer() {
 	s.NotNil(err)
 }
 
-func (s *CalldataSyncerTestSuite) TestProcessL1Blocks() {
+func (s *BlobSyncerTestSuite) TestProcessL1Blocks() {
 	s.Nil(s.s.ProcessL1Blocks(context.Background()))
 }
 
-func (s *CalldataSyncerTestSuite) TestProcessL1BlocksReorg() {
+func (s *BlobSyncerTestSuite) TestProcessL1BlocksReorg() {
 	s.ProposeAndInsertEmptyBlocks(s.p, s.s)
 	s.Nil(s.s.ProcessL1Blocks(context.Background()))
 }
 
-func (s *CalldataSyncerTestSuite) TestOnBlockProposed() {
+func (s *BlobSyncerTestSuite) TestOnBlockProposed() {
 	s.Nil(s.s.onBlockProposed(
 		context.Background(),
 		&bindings.TaikoL1ClientBlockProposed{BlockId: common.Big0},
@@ -85,7 +85,7 @@ func (s *CalldataSyncerTestSuite) TestOnBlockProposed() {
 	))
 }
 
-func (s *CalldataSyncerTestSuite) TestInsertNewHead() {
+func (s *BlobSyncerTestSuite) TestInsertNewHead() {
 	parent, err := s.s.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
 	l1Head, err := s.s.rpc.L1.BlockByNumber(context.Background(), nil)
@@ -117,7 +117,7 @@ func (s *CalldataSyncerTestSuite) TestInsertNewHead() {
 	s.Nil(err)
 }
 
-func (s *CalldataSyncerTestSuite) TestTreasuryIncomeAllAnchors() {
+func (s *BlobSyncerTestSuite) TestTreasuryIncomeAllAnchors() {
 	treasury := common.HexToAddress(os.Getenv("TREASURY"))
 	s.NotZero(treasury.Big().Uint64())
 
@@ -139,7 +139,7 @@ func (s *CalldataSyncerTestSuite) TestTreasuryIncomeAllAnchors() {
 	s.Zero(balanceAfter.Cmp(balance))
 }
 
-func (s *CalldataSyncerTestSuite) TestTreasuryIncome() {
+func (s *BlobSyncerTestSuite) TestTreasuryIncome() {
 	treasury := common.HexToAddress(os.Getenv("TREASURY"))
 	s.NotZero(treasury.Big().Uint64())
 
@@ -187,7 +187,7 @@ func (s *CalldataSyncerTestSuite) TestTreasuryIncome() {
 	s.Zero(balanceAfter.Cmp(balance))
 }
 
-func (s *CalldataSyncerTestSuite) initProposer() {
+func (s *BlobSyncerTestSuite) initProposer() {
 	prop := new(proposer.Proposer)
 	l1ProposerPrivKey, err := crypto.ToECDSA(common.FromHex(os.Getenv("L1_PROPOSER_PRIVATE_KEY")))
 	s.Nil(err)
@@ -237,6 +237,6 @@ func (s *CalldataSyncerTestSuite) initProposer() {
 	s.p = prop
 }
 
-func TestCalldataSyncerTestSuite(t *testing.T) {
-	suite.Run(t, new(CalldataSyncerTestSuite))
+func TestBlobSyncerTestSuite(t *testing.T) {
+	suite.Run(t, new(BlobSyncerTestSuite))
 }

--- a/driver/chain_syncer/chain_syncer.go
+++ b/driver/chain_syncer/chain_syncer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/taikoxyz/taiko-client/driver/chain_syncer/beaconsync"
-	"github.com/taikoxyz/taiko-client/driver/chain_syncer/calldata"
+	"github.com/taikoxyz/taiko-client/driver/chain_syncer/blob"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-client/pkg/rpc"
 )
@@ -24,8 +24,8 @@ type L2ChainSyncer struct {
 	rpc   *rpc.Client  // L1/L2 RPC clients
 
 	// Syncers
-	beaconSyncer   *beaconsync.Syncer
-	calldataSyncer *calldata.Syncer
+	beaconSyncer *beaconsync.Syncer
+	blobSyncer   *blob.Syncer
 
 	// Monitors
 	progressTracker *beaconsync.SyncProgressTracker
@@ -57,7 +57,7 @@ func New(
 		return nil, err
 	}
 	beaconSyncer := beaconsync.NewSyncer(ctx, rpc, state, syncMode, tracker)
-	calldataSyncer, err := calldata.NewSyncer(ctx, rpc, state, tracker, maxRetrieveExponent, blobServerEndpoint)
+	blobSyncer, err := blob.NewSyncer(ctx, rpc, state, tracker, maxRetrieveExponent, blobServerEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func New(
 		rpc:                   rpc,
 		state:                 state,
 		beaconSyncer:          beaconSyncer,
-		calldataSyncer:        calldataSyncer,
+		blobSyncer:            blobSyncer,
 		progressTracker:       tracker,
 		syncMode:              syncMode,
 		p2pSyncVerifiedBlocks: p2pSyncVerifiedBlocks,
@@ -127,7 +127,7 @@ func (s *L2ChainSyncer) Sync() error {
 	}
 
 	// Insert the proposed block one by one.
-	return s.calldataSyncer.ProcessL1Blocks(s.ctx)
+	return s.blobSyncer.ProcessL1Blocks(s.ctx)
 }
 
 // AheadOfProtocolVerifiedHead checks whether the L2 chain is ahead of verified head in protocol.
@@ -205,7 +205,7 @@ func (s *L2ChainSyncer) BeaconSyncer() *beaconsync.Syncer {
 	return s.beaconSyncer
 }
 
-// CalldataSyncer returns the inner calldata syncer.
-func (s *L2ChainSyncer) CalldataSyncer() *calldata.Syncer {
-	return s.calldataSyncer
+// BlobSyncer returns the inner blob syncer.
+func (s *L2ChainSyncer) BlobSyncer() *blob.Syncer {
+	return s.blobSyncer
 }

--- a/driver/chain_syncer/chain_syncer_test.go
+++ b/driver/chain_syncer/chain_syncer_test.go
@@ -92,7 +92,7 @@ func (s *ChainSyncerTestSuite) SetupTest() {
 
 func (s *ChainSyncerTestSuite) TestGetInnerSyncers() {
 	s.NotNil(s.s.BeaconSyncer())
-	s.NotNil(s.s.CalldataSyncer())
+	s.NotNil(s.s.BlobSyncer())
 }
 
 func (s *ChainSyncerTestSuite) TestSync() {
@@ -102,7 +102,7 @@ func (s *ChainSyncerTestSuite) TestSync() {
 func (s *ChainSyncerTestSuite) TestAheadOfProtocolVerifiedHead2() {
 	s.TakeSnapshot()
 	// propose a couple blocks
-	s.ProposeAndInsertEmptyBlocks(s.p, s.s.calldataSyncer)
+	s.ProposeAndInsertEmptyBlocks(s.p, s.s.blobSyncer)
 
 	// NOTE: need to prove the proposed blocks to be verified, writing helper function
 	// generate transactopts to interact with TaikoL1 contract with.

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -61,10 +61,10 @@ func (s *DriverTestSuite) TestProcessL1Blocks() {
 	l2Head1, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
 
-	s.Nil(s.d.ChainSyncer().CalldataSyncer().ProcessL1Blocks(context.Background()))
+	s.Nil(s.d.ChainSyncer().BlobSyncer().ProcessL1Blocks(context.Background()))
 
 	// Propose a valid L2 block
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 
 	l2Head2, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -72,7 +72,7 @@ func (s *DriverTestSuite) TestProcessL1Blocks() {
 	s.Greater(l2Head2.Number.Uint64(), l2Head1.Number.Uint64())
 
 	// Empty blocks
-	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
 	s.Nil(err)
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
@@ -107,9 +107,9 @@ func (s *DriverTestSuite) TestCheckL1ReorgToHigherFork() {
 	s.Nil(err)
 
 	// Propose two L2 blocks
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 
 	l1Head2, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -141,7 +141,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToHigherFork() {
 
 	s.Greater(l1Head4.Number.Uint64(), l1Head2.Number.Uint64())
 
-	s.Nil(s.d.ChainSyncer().CalldataSyncer().ProcessL1Blocks(context.Background()))
+	s.Nil(s.d.ChainSyncer().BlobSyncer().ProcessL1Blocks(context.Background()))
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -164,9 +164,9 @@ func (s *DriverTestSuite) TestCheckL1ReorgToLowerFork() {
 	s.Nil(err)
 
 	// Propose two L2 blocks
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 	time.Sleep(3 * time.Second)
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 
 	l1Head2, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -199,7 +199,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToLowerFork() {
 	s.Greater(l1Head4.Number.Uint64(), l1Head3.Number.Uint64())
 	s.Less(l1Head4.Number.Uint64(), l1Head2.Number.Uint64())
 
-	s.Nil(s.d.ChainSyncer().CalldataSyncer().ProcessL1Blocks(context.Background()))
+	s.Nil(s.d.ChainSyncer().BlobSyncer().ProcessL1Blocks(context.Background()))
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -220,9 +220,9 @@ func (s *DriverTestSuite) TestCheckL1ReorgToSameHeightFork() {
 	s.Nil(err)
 
 	// Propose two L2 blocks
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 	time.Sleep(3 * time.Second)
-	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().BlobSyncer())
 
 	l1Head2, err := s.d.rpc.L1.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -256,7 +256,7 @@ func (s *DriverTestSuite) TestCheckL1ReorgToSameHeightFork() {
 
 	s.Greater(l1Head4.Number.Uint64(), l1Head3.Number.Uint64())
 
-	s.Nil(s.d.ChainSyncer().CalldataSyncer().ProcessL1Blocks(context.Background()))
+	s.Nil(s.d.ChainSyncer().BlobSyncer().ProcessL1Blocks(context.Background()))
 
 	l2Head3, err := s.d.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -280,7 +280,7 @@ func (s *DriverTestSuite) TestStartClose() {
 
 func (s *DriverTestSuite) TestL1Current() {
 	// propose and insert a block
-	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().CalldataSyncer())
+	s.ProposeAndInsertEmptyBlocks(s.p, s.d.ChainSyncer().BlobSyncer())
 	// reset L1 current with increased height
 	s.Nil(s.d.state.ResetL1Current(s.d.ctx, common.Big1))
 }

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -45,7 +45,7 @@ func (s *ClientTestSuite) proposeEmptyBlockOp(ctx context.Context, proposer Prop
 
 func (s *ClientTestSuite) ProposeAndInsertEmptyBlocks(
 	proposer Proposer,
-	calldataSyncer CalldataSyncer,
+	blobSyncer BlobSyncer,
 ) []*bindings.TaikoL1ClientBlockProposed {
 	var events []*bindings.TaikoL1ClientBlockProposed
 
@@ -89,7 +89,7 @@ func (s *ClientTestSuite) ProposeAndInsertEmptyBlocks(
 	defer cancel()
 
 	s.Nil(backoff.Retry(func() error {
-		return calldataSyncer.ProcessL1Blocks(ctx)
+		return blobSyncer.ProcessL1Blocks(ctx)
 	}, backoff.NewExponentialBackOff()))
 
 	s.Nil(s.RPCClient.WaitTillL2ExecutionEngineSynced(context.Background()))
@@ -101,7 +101,7 @@ func (s *ClientTestSuite) ProposeAndInsertEmptyBlocks(
 // into L2 execution engine's local chain.
 func (s *ClientTestSuite) ProposeAndInsertValidBlock(
 	proposer Proposer,
-	calldataSyncer CalldataSyncer,
+	blobSyncer BlobSyncer,
 ) *bindings.TaikoL1ClientBlockProposed {
 	l1Head, err := s.RPCClient.L1.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
@@ -157,7 +157,7 @@ func (s *ClientTestSuite) ProposeAndInsertValidBlock(
 	defer cancel()
 
 	s.Nil(backoff.Retry(func() error {
-		return calldataSyncer.ProcessL1Blocks(ctx)
+		return blobSyncer.ProcessL1Blocks(ctx)
 	}, backoff.NewExponentialBackOff()))
 
 	s.Nil(s.RPCClient.WaitTillL2ExecutionEngineSynced(context.Background()))

--- a/internal/testutils/interfaces.go
+++ b/internal/testutils/interfaces.go
@@ -6,7 +6,7 @@ import (
 	"github.com/taikoxyz/taiko-client/cmd/utils"
 )
 
-type CalldataSyncer interface {
+type BlobSyncer interface {
 	ProcessL1Blocks(ctx context.Context) error
 }
 

--- a/proposer/proposer_test.go
+++ b/proposer/proposer_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/taikoxyz/taiko-client/bindings"
 	"github.com/taikoxyz/taiko-client/driver/chain_syncer/beaconsync"
-	"github.com/taikoxyz/taiko-client/driver/chain_syncer/calldata"
+	"github.com/taikoxyz/taiko-client/driver/chain_syncer/blob"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	txlistfetcher "github.com/taikoxyz/taiko-client/driver/txlist_fetcher"
 	"github.com/taikoxyz/taiko-client/internal/testutils"
@@ -29,7 +29,7 @@ import (
 
 type ProposerTestSuite struct {
 	testutils.ClientTestSuite
-	s      *calldata.Syncer
+	s      *blob.Syncer
 	p      *Proposer
 	cancel context.CancelFunc
 }
@@ -40,7 +40,7 @@ func (s *ProposerTestSuite) SetupTest() {
 	state2, err := state.New(context.Background(), s.RPCClient)
 	s.Nil(err)
 
-	syncer, err := calldata.NewSyncer(
+	syncer, err := blob.NewSyncer(
 		context.Background(),
 		s.RPCClient,
 		state2,

--- a/prover/event_handler/block_proposed_test.go
+++ b/prover/event_handler/block_proposed_test.go
@@ -27,7 +27,7 @@ func (s *EventHandlerTestSuite) TestBlockProposedHandle() {
 		ProveUnassignedBlocks: true,
 	}
 	handler := NewBlockProposedEventHandler(opts)
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.calldataSyncer)
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.blobSyncer)
 	err := handler.Handle(context.Background(), e, func() {})
 	s.Nil(err)
 }

--- a/prover/event_handler/transition_proved_test.go
+++ b/prover/event_handler/transition_proved_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/taikoxyz/taiko-client/bindings"
 	"github.com/taikoxyz/taiko-client/driver"
 	"github.com/taikoxyz/taiko-client/driver/chain_syncer/beaconsync"
-	"github.com/taikoxyz/taiko-client/driver/chain_syncer/calldata"
+	"github.com/taikoxyz/taiko-client/driver/chain_syncer/blob"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-client/internal/testutils"
 	"github.com/taikoxyz/taiko-client/pkg/jwt"
@@ -25,9 +25,9 @@ import (
 
 type EventHandlerTestSuite struct {
 	testutils.ClientTestSuite
-	d              *driver.Driver
-	proposer       *proposer.Proposer
-	calldataSyncer *calldata.Syncer
+	d          *driver.Driver
+	proposer   *proposer.Proposer
+	blobSyncer *blob.Syncer
 }
 
 func (s *EventHandlerTestSuite) SetupTest() {
@@ -57,7 +57,7 @@ func (s *EventHandlerTestSuite) SetupTest() {
 	s.Nil(testState.ResetL1Current(context.Background(), common.Big0))
 
 	tracker := beaconsync.NewSyncProgressTracker(s.RPCClient.L2, 30*time.Second)
-	s.calldataSyncer, err = calldata.NewSyncer(
+	s.blobSyncer, err = blob.NewSyncer(
 		context.Background(),
 		s.RPCClient,
 		testState,
@@ -120,7 +120,7 @@ func (s *EventHandlerTestSuite) TestTransitionProvedHandle() {
 		make(chan *proofProducer.ContestRequestBody),
 		true,
 	)
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.calldataSyncer)
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.blobSyncer)
 	err := handler.Handle(context.Background(), &bindings.TaikoL1ClientTransitionProved{
 		BlockId: e.BlockId,
 		Tier:    e.Meta.MinTier,

--- a/prover/proof_submitter/proof_submitter_test.go
+++ b/prover/proof_submitter/proof_submitter_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/taikoxyz/taiko-client/bindings"
 	"github.com/taikoxyz/taiko-client/bindings/encoding"
 	"github.com/taikoxyz/taiko-client/driver/chain_syncer/beaconsync"
-	"github.com/taikoxyz/taiko-client/driver/chain_syncer/calldata"
+	"github.com/taikoxyz/taiko-client/driver/chain_syncer/blob"
 	"github.com/taikoxyz/taiko-client/driver/state"
 	"github.com/taikoxyz/taiko-client/internal/testutils"
 	"github.com/taikoxyz/taiko-client/pkg/rpc"
@@ -29,11 +29,11 @@ import (
 
 type ProofSubmitterTestSuite struct {
 	testutils.ClientTestSuite
-	submitter      *ProofSubmitter
-	contester      *ProofContester
-	calldataSyncer *calldata.Syncer
-	proposer       *proposer.Proposer
-	proofCh        chan *producer.ProofWithHeader
+	submitter  *ProofSubmitter
+	contester  *ProofContester
+	blobSyncer *blob.Syncer
+	proposer   *proposer.Proposer
+	proofCh    chan *producer.ProofWithHeader
 }
 
 func (s *ProofSubmitterTestSuite) SetupTest() {
@@ -98,7 +98,7 @@ func (s *ProofSubmitterTestSuite) SetupTest() {
 
 	tracker := beaconsync.NewSyncProgressTracker(s.RPCClient.L2, 30*time.Second)
 
-	s.calldataSyncer, err = calldata.NewSyncer(
+	s.blobSyncer, err = blob.NewSyncer(
 		context.Background(),
 		s.RPCClient,
 		testState,
@@ -177,7 +177,7 @@ func (s *ProofSubmitterTestSuite) TestProofSubmitterSubmitProofMetadataNotFound(
 }
 
 func (s *ProofSubmitterTestSuite) TestSubmitProofs() {
-	events := s.ProposeAndInsertEmptyBlocks(s.proposer, s.calldataSyncer)
+	events := s.ProposeAndInsertEmptyBlocks(s.proposer, s.blobSyncer)
 
 	for _, e := range events {
 		s.Nil(s.submitter.RequestProof(context.Background(), e))
@@ -187,7 +187,7 @@ func (s *ProofSubmitterTestSuite) TestSubmitProofs() {
 }
 
 func (s *ProofSubmitterTestSuite) TestGuardianSubmitProofs() {
-	events := s.ProposeAndInsertEmptyBlocks(s.proposer, s.calldataSyncer)
+	events := s.ProposeAndInsertEmptyBlocks(s.proposer, s.blobSyncer)
 
 	for _, e := range events {
 		s.Nil(s.submitter.RequestProof(context.Background(), e))

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -164,7 +164,7 @@ func (s *ProverTestSuite) TestOnBlockProposed() {
 	s.Nil(err)
 	s.p.cfg.L1ProverPrivKey = l1ProverPrivKey
 	// Valid block
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 	s.Nil(s.p.blockProposedHandler.Handle(context.Background(), e, func() {}))
 	req := <-s.p.proofSubmissionCh
 	s.Nil(s.p.requestProofOp(req.Event, req.Tier))
@@ -173,7 +173,7 @@ func (s *ProverTestSuite) TestOnBlockProposed() {
 	// Empty blocks
 	for _, e = range s.ProposeAndInsertEmptyBlocks(
 		s.proposer,
-		s.d.ChainSyncer().CalldataSyncer(),
+		s.d.ChainSyncer().BlobSyncer(),
 	) {
 		s.Nil(s.p.blockProposedHandler.Handle(context.Background(), e, func() {}))
 		req := <-s.p.proofSubmissionCh
@@ -234,7 +234,7 @@ func (s *ProverTestSuite) TestOnBlockVerified() {
 func (s *ProverTestSuite) TestContestWrongBlocks() {
 	s.p.cfg.ContesterMode = false
 	s.p.initEventHandlers()
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 	s.Nil(s.p.transitionProvedHandler.Handle(context.Background(), &bindings.TaikoL1ClientTransitionProved{
 		BlockId: e.BlockId,
 		Tier:    e.Meta.MinTier,
@@ -325,7 +325,7 @@ func (s *ProverTestSuite) TestContestWrongBlocks() {
 }
 
 func (s *ProverTestSuite) TestProveExpiredUnassignedBlock() {
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 	sink := make(chan *bindings.TaikoL1ClientTransitionProved)
 
 	header, err := s.p.rpc.L2.HeaderByNumber(context.Background(), e.BlockId)
@@ -370,7 +370,7 @@ func (s *ProverTestSuite) TestGetSubmitterByTier() {
 }
 
 func (s *ProverTestSuite) TestProveOp() {
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 	sink := make(chan *bindings.TaikoL1ClientTransitionProved)
 
 	header, err := s.p.rpc.L2.HeaderByNumber(context.Background(), e.BlockId)
@@ -398,7 +398,7 @@ func (s *ProverTestSuite) TestGetBlockProofStatus() {
 	parent, err := s.p.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
 
-	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e := s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 
 	// No proof submitted
 	status, err := rpc.GetBlockProofStatus(context.Background(), s.p.rpc, e.BlockId, s.p.ProverAddress())
@@ -432,7 +432,7 @@ func (s *ProverTestSuite) TestGetBlockProofStatus() {
 	parent, err = s.p.rpc.L2.HeaderByNumber(context.Background(), nil)
 	s.Nil(err)
 
-	e = s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().CalldataSyncer())
+	e = s.ProposeAndInsertValidBlock(s.proposer, s.d.ChainSyncer().BlobSyncer())
 
 	status, err = rpc.GetBlockProofStatus(context.Background(), s.p.rpc, e.BlockId, s.p.ProverAddress())
 	s.Nil(err)


### PR DESCRIPTION
To match the names in our protocol