### PR TITLE
chore(pkg): replace `fmt.Errorf()` with `errors.New()` if no param required

### DIFF
--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -638,7 +638,7 @@ func (c *Client) getSyncedL1SnippetFromAnchor(
 			common.Hash{},
 			0,
 			0,
-			fmt.Errorf("failed to parse l1BlockHash from anchor transaction calldata")
+			errors.New("failed to parse l1BlockHash from anchor transaction calldata")
 	}
 	l1StateRoot, ok = args["_l1StateRoot"].([32]byte)
 	if !ok {
@@ -646,7 +646,7 @@ func (c *Client) getSyncedL1SnippetFromAnchor(
 			common.Hash{},
 			0,
 			0,
-			fmt.Errorf("failed to parse l1StateRoot from anchor transaction calldata")
+			errors.New("failed to parse l1StateRoot from anchor transaction calldata")
 	}
 	l1Height, ok = args["_l1BlockId"].(uint64)
 	if !ok {
@@ -654,7 +654,7 @@ func (c *Client) getSyncedL1SnippetFromAnchor(
 			common.Hash{},
 			0,
 			0,
-			fmt.Errorf("failed to parse l1Height from anchor transaction calldata")
+			errors.New("failed to parse l1Height from anchor transaction calldata")
 	}
 	parentGasUsed, ok = args["_parentGasUsed"].(uint32)
 	if !ok {
@@ -662,7 +662,7 @@ func (c *Client) getSyncedL1SnippetFromAnchor(
 			common.Hash{},
 			0,
 			0,
-			fmt.Errorf("failed to parse parentGasUsed from anchor transaction calldata")
+			errors.New("failed to parse parentGasUsed from anchor transaction calldata")
 	}
 
 	return l1BlockHash, l1StateRoot, l1Height, parentGasUsed, nil

--- a/prover/anchor_tx_validator/anchor_tx_validator.go
+++ b/prover/anchor_tx_validator/anchor_tx_validator.go
@@ -2,6 +2,7 @@ package anchortxvalidator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -69,7 +70,7 @@ func (v *AnchorTxValidator) GetAndValidateAnchorTxReceipt(
 	}
 
 	if len(receipt.Logs) == 0 {
-		return nil, fmt.Errorf("no event found in TaikoL2.anchor transaction receipt")
+		return nil, errors.New("no event found in TaikoL2.anchor transaction receipt")
 	}
 
 	return receipt, nil


### PR DESCRIPTION
similar to:https://github.com/ethereum/go-ethereum/pull/27329

string formatting takes time (even if there's nothing to format), and also that the errors.New is optimized away.