### PR TITLE
chore(prover): make raiko host endpoint required

### DIFF
--- a/cmd/flags/prover.go
+++ b/cmd/flags/prover.go
@@ -22,16 +22,17 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_CAPACITY"},
 	}
+	RaikoHostEndpoint = &cli.StringFlag{
+		Name:     "raiko.host",
+		Usage:    "RPC endpoint of a Raiko host service",
+		Required: true,
+		Category: proverCategory,
+		EnvVars:  []string{"RAIKO_HOST"},
+	}
 )
 
 // Optional flags used by prover.
 var (
-	RaikoHostEndpoint = &cli.StringFlag{
-		Name:     "raiko.host",
-		Usage:    "RPC endpoint of a Raiko host service",
-		Category: proverCategory,
-		EnvVars:  []string{"RAIKO_HOST"},
-	}
 	RaikoL1Endpoint = &cli.StringFlag{
 		Name:     "raiko.l1",
 		Usage:    "L1 RPC endpoint which will be sent to the Raiko service",


### PR DESCRIPTION
After #797 all provers guardian or not must have an sgx endpoint, so may as well make it required