### PR TITLE
chore(ci): speed up docker-build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,21 +6,69 @@ on:
     tags:
       - "v*"
 
+env:
+  REGISTRY_IMAGE: us-docker.pkg.dev/evmchain/images/taiko-client
+
 jobs:
-  push-docker-image:
+  build-binary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.21"
+        id: go
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: build
+        run: |
+          mkdir -p /tmp/taiko-client
+          ###
+          sudo apt update
+          sudo apt install gcc musl-dev linux-headers-generic git make build-essential -y
+          make build
+          mv ./bin/taiko-client /tmp/taiko-client/taiko-client-amd64
+          ###
+          make clean
+          sudo apt install g++-aarch64-linux-gnu gcc-arm-none-eabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu -y
+          make build-arm
+          mv ./bin/taiko-client /tmp/taiko-client/taiko-client-arm64
+          cp ./ci.dockerfile /tmp/taiko-client/Dockerfile
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: /tmp/taiko-client
+          if-no-files-found: error
+          retention-days: 1
+
+  build:
     name: Build and push docker image
     runs-on: ubuntu-latest
+    needs: build-binary
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Login to GAR
-        uses: docker/login-action@v2
+      - name: Download binaries
+        uses: actions/download-artifact@v3
         with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+          name: binaries
+          path: /tmp/taiko-client
+      - name: Rename binaries
+        run: |
+          mv /tmp/taiko-client/taiko-client-${{ matrix.platform }} /tmp/taiko-client/taiko-client
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -28,22 +76,68 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build
+        uses: docker/build-push-action@v4
+        id: build
+        with:
+          context: /tmp/taiko-client
+          file: /tmp/taiko-client/Dockerfile
+          platforms: linux/${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: |
-            us-docker.pkg.dev/evmchain/images/taiko-client
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag
             type=sha
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
+      - name: Login to GAR
+        uses: docker/login-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ LD_FLAGS := -ldflags "$(LD_FLAGS_ARGS)"
 build:
 	@GO111MODULE=on CGO_CFLAGS="-O -D__BLST_PORTABLE__" CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__" go build -v $(LD_FLAGS) -o bin/taiko-client cmd/main.go
 
+build-arm:
+	@GO111MODULE=on CGO_ENABLED=1 GOARCH=arm64 GOOS=linux CC=aarch64-linux-gnu-gcc CGO_CFLAGS="-O -D__BLST_PORTABLE__" CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__" go build -v $(LD_FLAGS) -o bin/taiko-client cmd/main.go
+
 clean:
 	@rm -rf bin/*
 

--- a/ci.dockerfile
+++ b/ci.dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+RUN apt update && apt install ca-certificates libstdc++6
+
+COPY taiko-client /usr/local/bin/
+RUN chmod +x /usr/local/bin/taiko-client
+
+EXPOSE 6060
+
+ENTRYPOINT ["taiko-client"]


### PR DESCRIPTION
Close #796 after merge

## Results

[A complete build and push operation](https://github.com/sljeff/taiko-client/actions/runs/8983757346) **took only 2m18s**. And there are [Docker images](https://hub.docker.com/r/kindjeff/taiko-client/tags)

(It took more than 17 minutes before this PR)

<img width="957" alt="image" src="https://github.com/taikoxyz/taiko-client/assets/10897528/15b91833-e472-4739-bc16-b6b7a5084fc9">

## Changes
**Optimizations:**
1. **Added build cache and mod cache**, which can reduce the compilation time by approximately three minutes.
   - Utilized `actions/cache@v3`.
2. **Switched to cross-compilation on the actions runner**, avoiding the use of qemu in containers, thus reducing at least 10 minutes of compilation time for the arm64 version.
   - Added `build-arm` in the Makefile.
   - Before executing `build-arm` in the `build-binary` job, it's necessary to install dependencies for cross-compilation.

**Other Changes:**
1. **Following Docker's official documentation to merge multi-platform builds into a single image**, automatically differentiating between platforms. [Docker Multi-Platform Build Documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/)
2. **Added a ci.dockerfile** specifically for adding binary files.

## Details
1. The [first binary compilation](https://github.com/sljeff/taiko-client/actions/runs/8983440765/job/24673222405) took 4m, and [subsequent compilations](https://github.com/sljeff/taiko-client/actions/runs/8983757346/job/24674170680) took just over a minute.
2. The compiled image supports two architectures: [Docker image](https://hub.docker.com/r/kindjeff/taiko-client/tags)
3. Both arm64 and amd64 binaries run smoothly.
<img width="1435" alt="image" src="https://github.com/taikoxyz/taiko-client/assets/10897528/e2fd5c4d-4edb-442f-9b5c-e87eb4b71145">
<img width="1436" alt="image" src="https://github.com/taikoxyz/taiko-client/assets/10897528/efb4e6cb-261f-4daf-bac7-2466b06b91a1">
